### PR TITLE
[dtbook-to-zedai] New rules for `a` elements

### DIFF
--- a/dtbook-to-zedai/etc/testing/utfx/translate-elems-attrs-to-zedai_test.xml
+++ b/dtbook-to-zedai/etc/testing/utfx/translate-elems-attrs-to-zedai_test.xml
@@ -1149,18 +1149,24 @@
         <utfx:name>Translate-DTBook2ZedAI: a</utfx:name>
         <utfx:assert-equal normalise-internal-whitespace="yes">
             <utfx:source>
+                <a/>
                 <a href="#abc"/>
+                <a href="#abc" id="foo"/>
                 <a href="page.html" external="true"/>
                 <a href="#def" external="false"/>
                 <a href="#para3" rel="REL"/>
                 <a href="#chapter4" rev="REV"/>
+                <a smilref="test.smil#foo"/>
             </utfx:source>
             <utfx:expected>
+                <ref/>
                 <ref ref="abc"/>
+                <ref ref="abc" xml:id="foo"/>
                 <ref xlink:href="page.html"/>
                 <ref ref="def"/>
                 <ref ref="para3" rel="REL"/>
                 <ref ref="chapter4" rev="REV"/>
+                <span/>
             </utfx:expected>
 
         </utfx:assert-equal>

--- a/dtbook-to-zedai/src/main/resources/xml/translate-elems-attrs-to-zedai.xsl
+++ b/dtbook-to-zedai/src/main/resources/xml/translate-elems-attrs-to-zedai.xsl
@@ -1003,7 +1003,8 @@
     </xsl:template>
 
     <xsl:template match="dtb:a">
-        <ref>
+        <xsl:element name="{if (empty(@href) and @smilref) then 'span' else 'ref'}">
+            <xsl:call-template name="attrs"/>
             <xsl:if test="@href">
                 <xsl:choose>
                     <xsl:when test="@external='true'">
@@ -1013,14 +1014,13 @@
                         <xsl:attribute name="ref" select="replace(@href, '#', '')"/>
                     </xsl:otherwise>
                 </xsl:choose>
-
+                
             </xsl:if>
             <xsl:copy-of select="@rev"/>
             <xsl:copy-of select="@rel"/>
-
             <xsl:apply-templates/>
-
-        </ref>
+            
+        </xsl:element>
     </xsl:template>
 
     <xsl:template match="dtb:dl">


### PR DESCRIPTION
- if the `a` element has a `@smilref` but no `@href`, it is considered a mere
  anchor an consequently converted as a `span` (isntead of a `ref`)
- `@id` and other global attributes are converted through

Comes with new unit tests.
