### PR TITLE
option "copy-external-resources": default value and consistent name

### DIFF
--- a/dtbook-to-zedai/src/main/resources/xml/dtbook-to-zedai.convert.xpl
+++ b/dtbook-to-zedai/src/main/resources/xml/dtbook-to-zedai.convert.xpl
@@ -80,7 +80,11 @@
         </p:documentation>
     </p:option>
 
-    <p:option name="opt-copy-external-resources"/>
+    <p:option name="opt-copy-external-resources" select="'true'">
+        <p:documentation>
+            Whether or not to include any referenced external resources like images and CSS-files in the output.
+        </p:documentation>
+    </p:option>
     
     <p:import href="http://xmlcalabash.com/extension/steps/library-1.0.xpl">
         <p:documentation>

--- a/dtbook-to-zedai/src/main/resources/xml/dtbook-to-zedai.xpl
+++ b/dtbook-to-zedai/src/main/resources/xml/dtbook-to-zedai.xpl
@@ -59,10 +59,10 @@
             <p px:role="desc">Language code of the input document.</p>
         </p:documentation>
     </p:option>
-    <p:option name="copy-images" required="false" px:type="boolean" select="'true'">
+    <p:option name="copy-external-resources" required="false" px:type="boolean" select="'true'">
         <p:documentation xmlns="http://www.w3.org/1999/xhtml">
-            <h2 px:role="name">copy-external-resources</h2>
-            <p px:role="desc">Copy any referenced external resources to the output directory.</p>
+            <h2 px:role="name">Copy external resources</h2>
+            <p px:role="desc">Include any referenced external resources like images and CSS-files to the output.</p>
         </p:documentation>
     </p:option>
     <p:import href="http://www.daisy.org/pipeline/modules/dtbook-utils/dtbook-load.xpl"/>


### PR DESCRIPTION
- dtbook-to-zedai: changed name of option from 'copy-images' to 'copy-external-resources'
- dtbook-to-zedai.convert: set default value of option 'copy-external-resources' to 'true'
