### PR TITLE
[html-to-epub3] Add support for `data:` URIs

### DIFF
--- a/html-to-epub3/src/main/resources/xml/xslt/html-clean-resources.xsl
+++ b/html-to-epub3/src/main/resources/xml/xslt/html-clean-resources.xsl
@@ -118,9 +118,11 @@
         </xsl:choose>
     </xsl:template>
 
-
     <xsl:template match="img[@src]">
         <xsl:choose>
+            <xsl:when test="pf:get-scheme(@src)='data'">
+                <xsl:copy-of select="."/>
+            </xsl:when>
             <xsl:when test="pf:is-absolute(@src)">
                 <xsl:message
                     select="concat('[WARNING] Replacing remote image ''',@src,''' by alternative text.')"/>
@@ -289,15 +291,18 @@
     </xsl:template>
 
     <xsl:template match="svg:foreignObject[@xlink:href]">
-        <xsl:message select="'[WARNING] Discarding SVG ''foreignObject'' element with external reference, not part of SVG 1.1'"/>
+        <xsl:message
+            select="'[WARNING] Discarding SVG ''foreignObject'' element with external reference, not part of SVG 1.1'"
+        />
     </xsl:template>
-    
+
     <xsl:template match="svg:foreignObject/@requiredExtensions">
         <xsl:attribute name="requiredExtensions" select="'http://www.idpf.org/2007/ops'"/>
     </xsl:template>
 
     <xsl:template match="svg:font-face-uri">
-        <svg:font-face-uri src="{f:safe-uri(@xlink:href)}" data-original-href="{normalize-space(@xlink:href)}">
+        <svg:font-face-uri src="{f:safe-uri(@xlink:href)}"
+            data-original-href="{normalize-space(@xlink:href)}">
             <xsl:apply-templates select="@* except @xlink:href | node()"/>
         </svg:font-face-uri>
     </xsl:template>
@@ -307,13 +312,13 @@
     </xsl:template>
 
     <xsl:template match="svg:image">
-        <svg:image src="{f:safe-uri(@xlink:href)}" data-original-href="{normalize-space(@xlink:href)}">
+        <svg:image src="{f:safe-uri(@xlink:href)}"
+            data-original-href="{normalize-space(@xlink:href)}">
             <xsl:apply-templates select="@* except @xlink:href | node()"/>
         </svg:image>
     </xsl:template>
 
-    <xsl:template match="svg:script[@xlink:href]">
-    </xsl:template>
+    <xsl:template match="svg:script[@xlink:href]"/>
 
     <xsl:template match="svg:video">
         <xsl:message select="'[WARNING] Discarding SVG ''video'' element, not part of SVG 1.1'"/>
@@ -323,20 +328,20 @@
     <!--–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––>
      |  MathML                                                                     |
     <|–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––-->
-    
-    
+
+
     <xsl:template match="m:math[@altimg]">
         <m:math altimg="{f:safe-uri(@altimg)}" data-original-href="{normalize-space(@altimg)}">
             <xsl:apply-templates select="@* except @altimg | node()"/>
         </m:math>
     </xsl:template>
-    
+
     <xsl:template match="m:mglyph[@src]">
         <m:math altimg="{f:safe-uri(@src)}" data-original-href="{normalize-space(@src)}">
             <xsl:apply-templates select="@* except @src | node()"/>
         </m:math>
     </xsl:template>
-    
+
     <!--–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––>
      |  Media Type Utils                                                           |
     <|–––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––-->

--- a/html-to-epub3/src/test/xspec/catalog.xml
+++ b/html-to-epub3/src/test/xspec/catalog.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+    <uri name="http://www.daisy.org/pipeline/modules/file-utils/xslt/uri-functions.xsl"
+        uri="mock-functions.xsl"/>
+</catalog>

--- a/html-to-epub3/src/test/xspec/html-clean-resources.xspec
+++ b/html-to-epub3/src/test/xspec/html-clean-resources.xspec
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description
+    xmlns="http://www.w3.org/1999/xhtml" 
+    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    stylesheet="../../main/resources/xml/xslt/html-clean-resources.xsl">
+    
+    <x:scenario label="An 'img' element">
+        <x:scenario label="with no @src">
+            <x:context>
+                <img/>    
+            </x:context>
+            <x:expect label="is converted as-is">
+                <img/>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="pointing to a relative image">
+            <x:context>
+                <img src="image.png"/>    
+            </x:context>
+            <x:expect label="is annotated with the original href">
+                <img src="image.png" data-original-href="image.png"/>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="pointing to a remote image">
+            <x:context>
+                <img src="http://www.example.com/image.png" alt="alt text"/>    
+            </x:context>
+            <x:expect label="is converted as a span, with alt-text as content">
+                <span>alt text</span>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="pointing to a non-supported image format">
+            <x:context>
+                <img src="image.tiff" alt="alt text"/>    
+            </x:context>
+            <x:expect label="is converted as a span, with alt-text as content">
+                <span>alt text</span>
+            </x:expect>
+        </x:scenario>
+        <x:scenario label="inlined as a 'data:' URI">
+            <x:context>
+                <img src="data:image/png;base64,ABCDEFG"/>    
+            </x:context>
+            <x:expect label="is kept as-is">
+                <img src="data:image/png;base64,ABCDEFG"/>
+            </x:expect>
+        </x:scenario>
+    </x:scenario>
+
+</x:description>

--- a/html-to-epub3/src/test/xspec/mock-functions.xsl
+++ b/html-to-epub3/src/test/xspec/mock-functions.xsl
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:pf="http://www.daisy.org/ns/pipeline/functions" exclude-result-prefixes="#all"
+    version="2.0">
+
+    <xsl:function name="pf:get-extension" as="xs:string">
+        <xsl:param name="uri" as="xs:string?"/>
+        <xsl:sequence select="replace($uri,'^.*\.([^.]*)$','$1')"/>
+    </xsl:function>
+
+    <xsl:function name="pf:get-scheme" as="xs:string">
+        <xsl:param name="uri" as="xs:string?"/>
+        <xsl:sequence select="replace($uri,'^(([^:]*):)?.+','$2')"/>
+    </xsl:function>
+
+    <xsl:function name="pf:is-absolute" as="xs:boolean">
+        <xsl:param name="uri" as="xs:string?"/>
+        <xsl:sequence select="matches($uri,'([^:]+:)?/.*')"/>
+    </xsl:function>
+
+    <xsl:function name="pf:is-relative" as="xs:boolean">
+        <xsl:param name="uri" as="xs:string?"/>
+        <xsl:sequence select="not(matches($uri,'^[^/]+:'))"/>
+    </xsl:function>
+
+    
+    <xsl:function name="pf:get-path" as="xs:string">
+        <xsl:param name="uri" as="xs:string?"/>
+        <xsl:sequence select="$uri"/>
+    </xsl:function>
+
+    <xsl:function name="pf:replace-path" as="xs:string">
+        <xsl:param name="uri" as="xs:string?"/>
+        <xsl:param name="path" as="xs:string?"/>
+        <xsl:sequence select="$uri"/>
+    </xsl:function>
+
+    <xsl:function name="pf:unescape-uri" as="xs:string">
+        <xsl:param name="uri" as="xs:string?"/>
+        <xsl:sequence select="replace($uri,' ','%20')"/>
+    </xsl:function>
+
+</xsl:stylesheet>


### PR DESCRIPTION
- html-clean-resources now leaves `img` elements with a `data:` URI
  in the `src` attribute untouched
- Added XSpec tests
