### PR TITLE
[html-clean-resources] Do not dicard links to self

### DIFF
--- a/html-to-epub3/src/main/resources/xml/xslt/html-clean-resources.xsl
+++ b/html-to-epub3/src/main/resources/xml/xslt/html-clean-resources.xsl
@@ -100,7 +100,7 @@
     <xsl:template match="a[@href]">
         <xsl:choose>
             <xsl:when
-                test="pf:is-relative(@href) and not(pf:file-exists(pf:unescape-uri(pf:get-path(@href))))"
+                test="pf:is-relative(@href) and pf:get-path(@href) and not(pf:file-exists(pf:unescape-uri(pf:get-path(@href))))"
                 use-when="function-available('pf:file-exists')">
                 <xsl:message
                     select="concat('[WARNING] Discarding link to non-existing resource ''',@href,'''.')"/>


### PR DESCRIPTION
Probably due to changes in the uri-utils functions, the HTML cleanup
tasks removed any links to anchors in the same file. This is now fixed.
