### PR TITLE
dtbook/zedai/daisy3-to-epub3 scripts use temporary directories

### DIFF
--- a/daisy3-to-epub3/src/main/resources/xml/xproc/daisy3-to-epub3.xpl
+++ b/daisy3-to-epub3/src/main/resources/xml/xproc/daisy3-to-epub3.xpl
@@ -38,6 +38,12 @@
             <p px:role="desc">Output directory for the produced EPUB.</p>
             <pre><code class="example">file:/home/user/epub3/</code></pre></p:documentation>
     </p:option>
+    <p:option name="temp-dir" required="true" px:output="temp" px:type="anyDirURI">
+        <p:documentation xmlns="http://www.w3.org/1999/xhtml">
+            <h2 px:role="name">Temporary directory</h2>
+            <p px:role="desc">Directory used for temporary files.</p>
+        </p:documentation>
+    </p:option>
     <p:option name="mediaoverlays" required="false" select="'true'" px:type="boolean">
         <p:documentation xmlns="http://www.w3.org/1999/xhtml">
             <h2 px:role="name">Include Media Overlays</h2>
@@ -90,8 +96,9 @@
     <!--=========================================================================-->
     <!--FIXME check options-->
     <p:variable name="output-dir-checked" select="resolve-uri(replace($output-dir,'(.+?)/?$','$1/'))"/>
-    <p:variable name="epub-dir" select="concat($output-dir-checked,'epub/')"/>
-    <p:variable name="content-dir" select="concat($output-dir-checked,'epub/EPUB/')"/>
+    <p:variable name="temp-dir-checked" select="resolve-uri(replace($temp-dir,'(.+?)/?$','$1/'))"/>
+    <p:variable name="epub-dir" select="concat($temp-dir-checked,'epub/')"/>
+    <p:variable name="content-dir" select="concat($temp-dir-checked,'epub/EPUB/')"/>
     <p:variable name="epub-file" select="concat($output-dir-checked,'result.epub')"/>
     <p:variable name="type" xmlns:opf="http://openebook.org/namespaces/oeb-package/1.0/"
         select="for $daisy-type in /opf:package/opf:metadata/opf:x-metadata/opf:meta[@name='dtb:multimediaType']/@content

--- a/dtbook-to-epub3/src/main/resources/xml/dtbook-to-epub3.xpl
+++ b/dtbook-to-epub3/src/main/resources/xml/dtbook-to-epub3.xpl
@@ -28,6 +28,13 @@
             <p px:role="desc">Directory where both temp-files and the resulting EPUB3 publication is stored.</p>
         </p:documentation>
     </p:option>
+    
+    <p:option name="temp-dir" required="true" px:output="temp" px:type="anyDirURI">
+        <p:documentation xmlns="http://www.w3.org/1999/xhtml">
+            <h2 px:role="name">Temporary directory</h2>
+            <p px:role="desc">Directory used for temporary files.</p>
+        </p:documentation>
+    </p:option>
 
     <p:option name="assert-valid" required="false" px:type="boolean" select="'true'">
         <p:documentation xmlns="http://www.w3.org/1999/xhtml">
@@ -106,7 +113,7 @@
             <p:input port="in-memory.in">
                 <p:pipe port="in-memory.out" step="convert.dtbook-to-zedai"/>
             </p:input>
-            <p:with-option name="output-dir" select="$output-dir-uri"/>
+            <p:with-option name="output-dir" select="$temp-dir"/>
         </px:zedai-to-epub3-convert>
 
         <px:epub3-store name="store">

--- a/zedai-to-epub3/src/main/resources/xml/xproc/zedai-to-epub3.xpl
+++ b/zedai-to-epub3/src/main/resources/xml/xproc/zedai-to-epub3.xpl
@@ -20,6 +20,13 @@
             <p px:role="desc">Output directory for the EPUB.</p>
         </p:documentation>
     </p:option>
+    
+    <p:option name="temp-dir" required="true" px:output="temp" px:type="anyDirURI">
+        <p:documentation xmlns="http://www.w3.org/1999/xhtml">
+            <h2 px:role="name">Temporary directory</h2>
+            <p px:role="desc">Directory used for temporary files.</p>
+        </p:documentation>
+    </p:option>
 
     <p:import href="zedai-to-epub3.convert.xpl"/>
 
@@ -60,7 +67,7 @@
         <p:variable name="output-dir-uri" select="/*/@href">
             <p:pipe port="result" step="output-dir-uri"/>
         </p:variable>
-        <p:variable name="epub-file-uri" select="concat($output-dir-uri,replace($input-uri,'^.*/([^/]*)\.[^/\.]*$','$1'),'.epub')"/>
+        <p:variable name="epub-file-uri" select="concat($output-dir-uri,replace($input-uri,'^.*/([^/]*?)(\.[^/\.]*)?$','$1'),'.epub')"/>
 
         <px:zedai-load name="load">
             <p:input port="source">
@@ -72,7 +79,7 @@
             <p:input port="in-memory.in">
                 <p:pipe port="in-memory.out" step="load"/>
             </p:input>
-            <p:with-option name="output-dir" select="$output-dir-uri"/>
+            <p:with-option name="output-dir" select="$temp-dir"/>
         </px:zedai-to-epub3-convert>
         
         <px:epub3-store>


### PR DESCRIPTION
- all three scripts have a new `temp-dir` option
- fixes daisy/pipeline-issues#283
- fixes daisy/pipeline-issues#388
- fixes daisy/pipeline-issues#389

<!---
@huboard:{"order":37.0,"custom_state":""}
-->
