### PR TITLE
zedai-to-epub3: Use the computed nav doc explicitly

### DIFF
--- a/zedai-to-epub3/src/main/resources/xml/xproc/zedai-to-epub3.convert.xpl
+++ b/zedai-to-epub3/src/main/resources/xml/xproc/zedai-to-epub3.convert.xpl
@@ -327,6 +327,9 @@
             </p:input>
             <p:with-option name="result-uri" select="$opf-base"/>
             <p:with-option name="compatibility-mode" select="'false'"/>
+            <p:with-option name="nav-uri" select="base-uri(/*)">
+                <p:pipe port="html-file" step="navigation-doc"/>
+            </p:with-option>
             <!--TODO configurability for other META-INF files ?-->
         </px:epub3-pub-create-package-doc>
 


### PR DESCRIPTION
Use the `px:create-package-doc` `nav-uri` option to force the Nav Doc
to declare in the the OPF to be the computed Nav Doc.
This prevents some conflict if the HTML contains multiple `toc` `nav`s.

Fixes daisy/pipeline-issues#416
