### PR TITLE
Pass output dir URI to TTS modules

### DIFF
--- a/dtbook-to-daisy3/src/main/resources/xml/dtbook-to-daisy3.convert.xpl
+++ b/dtbook-to-daisy3/src/main/resources/xml/dtbook-to-daisy3.convert.xpl
@@ -142,6 +142,7 @@
       <p:pipe port="config" step="main"/>
     </p:input>
     <p:with-option name="audio" select="$audio"/>
+    <p:with-option name="output-dir" select="$output-fileset-base"/>
   </px:tts-for-dtbook>
 
   <p:delete name="filtered-dtbook-fileset"


### PR DESCRIPTION
- must be synchronized with pipeline-mod-tts's remote-log branch
