### PR TITLE
Restore '--x-audio' option to enable TTS

### DIFF
--- a/dtbook-to-daisy3/src/main/resources/xml/dtbook-to-daisy3.xpl
+++ b/dtbook-to-daisy3/src/main/resources/xml/dtbook-to-daisy3.xpl
@@ -37,8 +37,15 @@
 
   <p:option name="tts-config" required="false" px:type="anyFileURI" select="''">
     <p:documentation xmlns="http://www.w3.org/1999/xhtml">
-      <h2 px:role="name"> Text-To-Speech configuration file</h2>
+      <h2 px:role="name">Text-To-Speech configuration file</h2>
       <p px:role="desc">Configuration file for the Text-To-Speech.</p>
+    </p:documentation>
+  </p:option>
+
+  <p:option name="audio" required="false" px:type="boolean" select="'false'">
+    <p:documentation xmlns="http://www.w3.org/1999/xhtml">
+      <h2 px:role="name">Enable Text-To-Speech</h2>
+      <p px:role="desc">Whether to use a speech synthesizer to produce audio files.</p>
     </p:documentation>
   </p:option>
 
@@ -155,7 +162,7 @@
     <p:xpath-context>
       <p:empty/>
     </p:xpath-context>
-    <p:when test="$tts-config != ''">
+    <p:when test="$audio = 'true'">
       <p:output port="result" primary="true"/>
       <px:inline-css-speech>
 	<p:input port="source">
@@ -194,7 +201,7 @@
     <p:with-option name="output-fileset-base" select="/*/@href">
       <p:pipe port="result" step="output-dir-uri"/>
     </p:with-option>
-    <p:with-option name="audio" select="$tts-config != ''"/>
+    <p:with-option name="audio" select="$audio"/>
   </px:dtbook-to-daisy3-convert>
 
   <px:fileset-store>

--- a/dtbook-to-epub3/src/main/resources/xml/dtbook-to-epub3.xpl
+++ b/dtbook-to-epub3/src/main/resources/xml/dtbook-to-epub3.xpl
@@ -45,11 +45,17 @@
 
     <p:option name="tts-config" required="false" px:type="anyFileURI" select="''">
       <p:documentation xmlns="http://www.w3.org/1999/xhtml">
-	<h2 px:role="name"> Text-To-Speech configuration file</h2>
+	<h2 px:role="name">Text-To-Speech configuration file</h2>
 	<p px:role="desc">Configuration file for the Text-To-Speech.</p>
       </p:documentation>
     </p:option>
 
+    <p:option name="audio" required="false" px:type="boolean" select="'false'">
+      <p:documentation xmlns="http://www.w3.org/1999/xhtml">
+	<h2 px:role="name">Enable Text-To-Speech</h2>
+	<p px:role="desc">Whether to use a speech synthesizer to produce audio files.</p>
+      </p:documentation>
+    </p:option>
 
     <p:import href="http://www.daisy.org/pipeline/modules/dtbook-utils/library.xpl"/>
     <p:import href="http://www.daisy.org/pipeline/modules/dtbook-to-zedai/library.xpl"/>
@@ -120,7 +126,7 @@
 	  </p:otherwise>
 	</p:choose>
 	<p:choose name="css-inlining">
-	  <p:when test="$tts-config != ''">
+	  <p:when test="$audio = 'true'">
 	    <p:output port="result" primary="true"/>
 	    <px:inline-css-speech>
 	      <p:input port="source">
@@ -174,7 +180,7 @@
 	      <p:pipe port="result" step="load-tts-config"/>
             </p:input>
             <p:with-option name="output-dir" select="$temp-dir"/>
-            <p:with-option name="audio" select="$tts-config != ''"/>
+            <p:with-option name="audio" select="$audio"/>
         </px:zedai-to-epub3-convert>
 
         <px:epub3-store name="store">

--- a/zedai-to-epub3/src/main/resources/xml/xproc/zedai-to-epub3.convert.xpl
+++ b/zedai-to-epub3/src/main/resources/xml/xproc/zedai-to-epub3.convert.xpl
@@ -288,6 +288,7 @@
 	<p:pipe port="tts-config" step="zedai-to-epub3.convert"/>
       </p:input>
       <p:with-option name="audio" select="$audio"/>
+      <p:with-option name="output-dir" select="$output-dir"/>
     </px:tts-for-epub3>
 
     <!--=========================================================================-->

--- a/zedai-to-epub3/src/main/resources/xml/xproc/zedai-to-epub3.xpl
+++ b/zedai-to-epub3/src/main/resources/xml/xproc/zedai-to-epub3.xpl
@@ -30,8 +30,15 @@
 
     <p:option name="tts-config" required="false" px:type="anyFileURI" select="''">
       <p:documentation xmlns="http://www.w3.org/1999/xhtml">
-	<h2 px:role="name"> Text-To-Speech configuration file</h2>
+	<h2 px:role="name">Text-To-Speech configuration file</h2>
 	<p px:role="desc">Configuration file for the Text-To-Speech.</p>
+      </p:documentation>
+    </p:option>
+
+    <p:option name="audio" required="false" px:type="boolean" select="'false'">
+      <p:documentation xmlns="http://www.w3.org/1999/xhtml">
+	<h2 px:role="name">Enable Text-To-Speech</h2>
+	<p px:role="desc">Whether to use a speech synthesizer to produce audio files.</p>
       </p:documentation>
     </p:option>
 
@@ -101,7 +108,7 @@
 	</p:choose>
 
 	<p:choose name="css-inlining">
-	  <p:when test="$tts-config != ''">
+	  <p:when test="$audio = 'true'">
 	    <p:output port="result" primary="true"/>
 	    <px:inline-css-speech>
 	      <p:input port="source">
@@ -137,7 +144,7 @@
 	      <p:pipe port="result" step="load-tts-config"/>
 	    </p:input>
             <p:with-option name="output-dir" select="$temp-dir"/>
-	    <p:with-option name="audio" select="$tts-config != ''"/>
+	    <p:with-option name="audio" select="$audio"/>
         </px:zedai-to-epub3-convert>
 
         <px:epub3-store>


### PR DESCRIPTION
- must be in sync with 'remote-log-epub3' branch of pipeline-mod-tts
- in dtbook-to-epub3 and zedai-to-epub3, pass the 'output-dir' option for the TTS logs
