### PR TITLE
fixes support for validating dtbook 2005-1 and 1.1.0

### DIFF
--- a/dtbook-validator/src/main/resources/xml/dtbook-validator.select-schema.xpl
+++ b/dtbook-validator/src/main/resources/xml/dtbook-validator.select-schema.xpl
@@ -77,14 +77,14 @@
         <p:when test="$dtbook-version = '2005-1'">
             <p:identity>
                 <p:input port="source">
-                    <p:document href="./schema/rng/dtbook-2005-1.rng"/>
+                    <p:document href="./schema/rng/dtbook/dtbook-2005-1.rng"/>
                 </p:input>
             </p:identity>
         </p:when>
         <p:when test="$dtbook-version = '1.1.0'">
             <p:identity>
                 <p:input port="source">
-                    <p:document href="./schema/rng/dtbook-1.1.0.rng"/>
+                    <p:document href="./schema/rng/dtbook/dtbook-1.1.0.rng"/>
                 </p:input>
             </p:identity>
         </p:when>

--- a/dtbook-validator/src/main/resources/xml/dtbook-validator.validate.xpl
+++ b/dtbook-validator/src/main/resources/xml/dtbook-validator.validate.xpl
@@ -79,7 +79,7 @@
         <p:documentation>Helper step: check that referenced images exist on disk.</p:documentation>
     </p:import>
     
-    <p:variable name="dtbook-version" select="dtb:dtbook/@version">
+    <p:variable name="dtbook-version" select="*/@version">
         <p:pipe port="source" step="dtbook-validator.validate"/>
     </p:variable>
     <p:variable name="filename" select="tokenize($base-uri, '/')[last()]"/>


### PR DESCRIPTION
 * hrefs to RNGs were wrong for 2005-1 and 1.1.0
 * 1.1.0 uses the default namespace which must be taken into consideration when extracting the version attribute