### PR TITLE
Fix MathML ID conversion in dtbook-to-zedai

### DIFF
--- a/dtbook-to-zedai/src/main/resources/xml/translate-mathml-to-zedai.xsl
+++ b/dtbook-to-zedai/src/main/resources/xml/translate-mathml-to-zedai.xsl
@@ -2,6 +2,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.0"
     xmlns:m="http://www.w3.org/1998/Math/MathML"
+    xmlns:dtbook="http://www.daisy.org/z3986/2005/dtbook/"
     xmlns:pf="http://www.daisy.org/ns/pipeline/functions"
     exclude-result-prefixes="#all">
 
@@ -11,22 +12,27 @@
 
     <xsl:output indent="yes" method="xml"/>
     
+    <xsl:template match="m:*/@*">
+        <xsl:copy/>
+    </xsl:template>
+    <xsl:template match="m:*/@dtbook:*"/>
+    
     
     <xsl:template match="m:*">
         <xsl:copy  copy-namespaces="no">
-            <xsl:copy-of select="@* except @id"/>
+            <xsl:apply-templates select="@*"/>
             <xsl:apply-templates/>
         </xsl:copy>
     </xsl:template>
     
     <xsl:template match="m:math">
         <m:math>
-            <xsl:copy-of select="@* except @id"/>
+            <xsl:apply-templates select="@*"/>
             <xsl:choose>
                 <xsl:when test="(@altimg or @alttext) and not(m:semantics)">
                     <m:semantics>
                         <xsl:apply-templates/>
-                        <xsl:apply-templates select="@altimg|@alttext"/>
+                        <xsl:apply-templates select="@altimg|@alttext" mode="alt"/>
                     </m:semantics>
                 </xsl:when>
                 <xsl:otherwise>
@@ -37,15 +43,15 @@
     </xsl:template>
     <xsl:template match="m:math/m:semantics">
         <m:semantics>
-            <xsl:copy-of select="@* except @id"/>
+            <xsl:apply-templates select="@*"/>
             <xsl:apply-templates/>
-            <xsl:apply-templates select="../@altimg|../@alttext"/>
+            <xsl:apply-templates select="../@altimg|../@alttext" mode="alt"/>
         </m:semantics>
     </xsl:template>
-    <xsl:template match="m:math/@altimg">
+    <xsl:template match="m:math/@altimg" mode="alt">
         <m:annotation src="{.}" encoding="{pf:mediatype-from-extension(pf:get-extension(.))}"/>
     </xsl:template>
-    <xsl:template match="m:math/@alttext">
+    <xsl:template match="m:math/@alttext" mode="alt">
         <m:annotation encoding="text/plain"><xsl:value-of select="."/></m:annotation>
     </xsl:template>
 </xsl:stylesheet>

--- a/dtbook-to-zedai/src/test/xspec/translate-mathml-to-zedai_test.xspec
+++ b/dtbook-to-zedai/src/test/xspec/translate-mathml-to-zedai_test.xspec
@@ -105,7 +105,14 @@
                 </m:mroot>
             </m:math>
         </x:context>
-        <x:expect label="should be discarded" test="empty(//(@id|@xml:id))"/>
+        <x:expect label="are kept">
+            <m:math id="foo">
+                <m:mroot id="bar">
+                    <m:mi>x</m:mi>
+                    <m:mn>3</m:mn>
+                </m:mroot>
+            </m:math>
+        </x:expect>
     </x:scenario>
 
     <x:scenario label="MathML @alttext and @altimg">


### PR DESCRIPTION
ZedAI schemadoc seems to say `@id` is not allowed on MathML elements
so we discarded it (and it resulted in some IDs lost during the
conversion).
It appears that the MathML feature's schemas do allow `@id` (in place
of ZedAI's usual `@xml:id`), so we now keep those during the conversion,
which consequently fixes ID-loss issues.

This change also gets rid of `@dtbook:*` attributes in MathML markup.