### PR TITLE
scripts: updated dependencies

### DIFF
--- a/daisy202-to-epub3/src/main/resources/xml/convert/package.xpl
+++ b/daisy202-to-epub3/src/main/resources/xml/convert/package.xpl
@@ -54,7 +54,6 @@
         <p:documentation xmlns="http://www.w3.org/1999/xhtml">URI to the base directory where the EPUB3-files should eventually be stored.</p:documentation>
     </p:option>
 
-    <p:import href="http://xmlcalabash.com/extension/steps/library-1.0.xpl"/>
     <p:import href="http://www.daisy.org/pipeline/modules/fileset-utils/library.xpl"/>
     <p:import href="http://www.daisy.org/pipeline/modules/mediatype-utils/library.xpl"/>
     <p:import href="http://www.daisy.org/pipeline/modules/epub3-pub-utils/library.xpl"/>

--- a/daisy202-to-epub3/src/main/resources/xml/daisy202-to-epub3.xpl
+++ b/daisy202-to-epub3/src/main/resources/xml/daisy202-to-epub3.xpl
@@ -56,7 +56,6 @@
         </p:documentation>
     </p:option>
 
-    <p:import href="http://xmlcalabash.com/extension/steps/library-1.0.xpl"/>
     <p:import href="http://www.daisy.org/pipeline/modules/file-utils/library.xpl"/>
     <p:import href="http://www.daisy.org/pipeline/modules/fileset-utils/library.xpl"/>
     <p:import href="http://www.daisy.org/pipeline/modules/epub3-ocf-utils/library.xpl"/>

--- a/daisy202-validator/src/main/resources/META-INF/catalog.xml
+++ b/daisy202-validator/src/main/resources/META-INF/catalog.xml
@@ -18,5 +18,7 @@
     <nextCatalog catalog="org:daisy:pipeline:modules:common-utils"/>
     <nextCatalog catalog="org:daisy:pipeline:modules:fileset-utils"/>
     <nextCatalog catalog="org:daisy:pipeline:modules:validation-utils"/>
+    <nextCatalog catalog="org:daisy:pipeline:modules:mediaoverlay-utils"/>
+    <nextCatalog catalog="org:daisy:pipeline:modules:mediatype-utils"/>
     
 </catalog>

--- a/daisy3-to-epub3/src/main/resources/xml/internal/list-audio-clips.xpl
+++ b/daisy3-to-epub3/src/main/resources/xml/internal/list-audio-clips.xpl
@@ -16,7 +16,6 @@
     </p:output>
 
 
-    <p:import href="http://xmlcalabash.com/extension/steps/library-1.0.xpl"/>
     <p:import href="http://www.daisy.org/pipeline/modules/fileset-utils/library.xpl"/>
 
     <!--TODO add support for audio transcoding-->

--- a/dtbook-to-daisy3/src/main/resources/META-INF/catalog.xml
+++ b/dtbook-to-daisy3/src/main/resources/META-INF/catalog.xml
@@ -12,4 +12,7 @@
   <nextCatalog catalog="org:daisy:pipeline:modules:dtbook-utils"/>
   <nextCatalog catalog="org:daisy:pipeline:modules:fileset-utils"/>
   <nextCatalog catalog="org:daisy:pipeline:modules:css-speech"/>
+  <nextCatalog catalog="org:daisy:pipeline:modules:common-utils"/>
+  <nextCatalog catalog="org:daisy:pipeline:modules:ssml-to-audio"/>
+  <nextCatalog catalog="org:daisy:pipeline:modules:file-utils"/>
 </catalog>

--- a/dtbook-to-html/src/main/resources/META-INF/catalog.xml
+++ b/dtbook-to-html/src/main/resources/META-INF/catalog.xml
@@ -5,7 +5,7 @@
   <nextCatalog catalog="org:daisy:pipeline:modules:dtbook-utils"/>
   <nextCatalog catalog="org:daisy:pipeline:modules:file-utils"/>
   <nextCatalog catalog="org:daisy:pipeline:modules:dtbook-to-zedai"/>
-  <nextCatalog catalog="org:daisy:pipeline:modules:html-utils"/>
   <nextCatalog catalog="org:daisy:pipeline:modules:zedai-to-html"/>
   <nextCatalog catalog="org:daisy:pipeline:modules:common-utils" />
+  <nextCatalog catalog="org:daisy:pipeline:modules:fileset-utils" />
 </catalog>

--- a/dtbook-to-html/src/main/resources/xml/dtbook-to-html.xpl
+++ b/dtbook-to-html/src/main/resources/xml/dtbook-to-html.xpl
@@ -47,7 +47,6 @@
         href="http://www.daisy.org/pipeline/modules/dtbook-to-zedai/library.xpl"/>
     <p:import href="http://www.daisy.org/pipeline/modules/zedai-to-html/library.xpl"/>
     <p:import href="http://www.daisy.org/pipeline/modules/fileset-utils/library.xpl"/>
-    <p:import href="http://xmlcalabash.com/extension/steps/library-1.0.xpl"/>
     <p:import href="http://www.daisy.org/pipeline/modules/common-utils/library.xpl"/>
 
     

--- a/dtbook-to-odt/src/main/resources/META-INF/catalog.xml
+++ b/dtbook-to-odt/src/main/resources/META-INF/catalog.xml
@@ -9,6 +9,6 @@
   <nextCatalog catalog="org:daisy:pipeline:modules:dtbook-utils"/>
   <nextCatalog catalog="org:daisy:pipeline:modules:odt-utils"/>
   <nextCatalog catalog="org:daisy:pipeline:modules:file-utils"/>
-  <nextCatalog catalog="org:daisy:pipeline:modules:image-utils"/>
   <nextCatalog catalog="org:daisy:pipeline:modules:asciimath-utils"/>
+  <nextCatalog catalog="org:daisy:pipeline:modules:image-utils"/>
 </catalog>

--- a/dtbook-to-zedai/src/main/resources/META-INF/catalog.xml
+++ b/dtbook-to-zedai/src/main/resources/META-INF/catalog.xml
@@ -10,4 +10,5 @@
   <nextCatalog catalog="org:daisy:pipeline:modules:mediatype-utils"/>
   <nextCatalog catalog="org:daisy:pipeline:modules:dtbook-validator"/>
   <nextCatalog catalog="org:daisy:pipeline:modules:common-utils" />
+  <nextCatalog catalog="org:daisy:pipeline:modules:css-speech" />
 </catalog>

--- a/dtbook-to-zedai/src/main/resources/xml/dtbook2005-3-to-zedai.xpl
+++ b/dtbook-to-zedai/src/main/resources/xml/dtbook2005-3-to-zedai.xpl
@@ -16,8 +16,6 @@
         <p:pipe port="result" step="anchor-floating-annotations"/>
     </p:output>
 
-    <p:import href="http://xmlcalabash.com/extension/steps/library-1.0.xpl"/>
-
     <p:documentation>Preprocess certain inline elements by making them into spans. This streamlines
         the number of transformation cases that need to be dealt with later.</p:documentation>
     <p:xslt name="rename-to-span">

--- a/dtbook-validator/src/main/resources/xml/dtbook-validator.select-schema.xpl
+++ b/dtbook-validator/src/main/resources/xml/dtbook-validator.select-schema.xpl
@@ -39,10 +39,6 @@
         </p:documentation>
     </p:option>
     
-    <p:import href="http://xmlcalabash.com/extension/steps/library-1.0.xpl">
-        <p:documentation>Calabash extension steps.</p:documentation>
-    </p:import>
-    
     <!-- Based on the DTBook and MathML version, provide the correct RelaxNG schema on the output port -->
     <p:choose name="choose-schema">
         <p:when test="$dtbook-version = '2005-3' and $mathml-version = '3.0'">

--- a/dtbook-validator/src/main/resources/xml/dtbook-validator.xpl
+++ b/dtbook-validator/src/main/resources/xml/dtbook-validator.xpl
@@ -115,32 +115,33 @@
         </p:input>
     </px:message>
     <p:sink/>
-
-    <px:fileset-add-entry name="create-fileset-for-dtbook-doc">
+    
+    <px:fileset-create>
+        <p:with-option name="base" select="replace($input-dtbook,'[^/]+$','')"/>
+    </px:fileset-create>
+    <px:fileset-add-entry>
         <p:with-option name="href" select="$input-dtbook"/>
-        <p:input port="source">
-            <p:inline>
-                <d:fileset/>
-            </p:inline>
-        </p:input>
     </px:fileset-add-entry>
-
-
-    <px:message message="DTBook validator: Checking that DTBook document exists and is well-formed"/>
+    <p:identity name="create-fileset-for-dtbook-doc"/>
     <p:sink/>
-
+    
     <!--check that the package document is well-formed XML -->
-    <px:check-files-wellformed name="check-dtbook-wellformed">
+    <p:identity>
         <p:input port="source">
             <p:pipe port="result" step="create-fileset-for-dtbook-doc"/>
         </p:input>
-    </px:check-files-wellformed>
+    </p:identity>
+    <px:message message="DTBook validator: Checking that DTBook document exists and is well-formed"/>
+    <px:check-files-wellformed name="check-dtbook-wellformed"/>
+    <p:identity>
+        <p:input port="source">
+            <p:pipe port="validation-status" step="check-dtbook-wellformed"/>
+        </p:input>
+    </p:identity>
+    <px:message message="DTBook validator: Done checking that DTBook document exists and is well-formed"/>
 
     <p:choose name="if-dtbook-wellformed">
-        <p:xpath-context>
-            <p:pipe port="validation-status" step="check-dtbook-wellformed"/>
-        </p:xpath-context>
-
+        
         <!-- if the dtbook file was well-formed -->
         <p:when test="d:validation-status/@result = 'ok'">
 

--- a/epub3-to-daisy202/src/main/resources/META-INF/catalog.xml
+++ b/epub3-to-daisy202/src/main/resources/META-INF/catalog.xml
@@ -4,10 +4,10 @@
   <uri name="http://www.daisy.org/pipeline/modules/epub3-to-daisy202/xproc/epub3-to-daisy202.xpl" uri="../xml/xproc/epub3-to-daisy202.xpl" px:script="true"/>
   <uri name="http://www.daisy.org/pipeline/modules/epub3-to-daisy202/xproc/library.xpl" uri="../xml/xproc/library.xpl"/>
 
-  <nextCatalog catalog="org:daisy:pipeline:modules:epub3-nav-utils"/>
-  <nextCatalog catalog="org:daisy:pipeline:modules:epub3-ocf-utils"/>
-  <nextCatalog catalog="org:daisy:pipeline:modules:epub3-pub-utils"/>
-  <nextCatalog catalog="org:daisy:pipeline:modules:fileset-utils"/>
   <nextCatalog catalog="org:daisy:pipeline:modules:file-utils"/>
+  <nextCatalog catalog="org:daisy:pipeline:modules:fileset-utils"/>
+  <nextCatalog catalog="org:daisy:pipeline:modules:zip-utils"/>
+  <nextCatalog catalog="org:daisy:pipeline:modules:common-utils"/>
+  <nextCatalog catalog="org:daisy:pipeline:modules:html-utils"/>
 
 </catalog>

--- a/epub3-to-daisy202/src/main/resources/xml/xproc/epub3-to-daisy202.xpl
+++ b/epub3-to-daisy202/src/main/resources/xml/xproc/epub3-to-daisy202.xpl
@@ -29,10 +29,8 @@
     </p:option>
 
     <p:import href="step/epub3-to-daisy202.convert.xpl"/>
-    <p:import href="http://www.daisy.org/pipeline/modules/validation-utils/library.xpl"/>
     <p:import href="http://www.daisy.org/pipeline/modules/zip-utils/library.xpl"/>
     <p:import href="http://www.daisy.org/pipeline/modules/fileset-utils/library.xpl"/>
-    <p:import href="http://www.daisy.org/pipeline/modules/mediatype-utils/library.xpl"/>
     <p:import href="http://www.daisy.org/pipeline/modules/common-utils/library.xpl"/>
 
     <p:variable name="epub-href" select="resolve-uri($epub,base-uri(/*))">

--- a/epub3-to-daisy202/src/main/resources/xml/xproc/step/epub3-to-daisy202.convert.xpl
+++ b/epub3-to-daisy202/src/main/resources/xml/xproc/step/epub3-to-daisy202.convert.xpl
@@ -16,7 +16,6 @@
 
     <p:option name="bundle-dtds" select="'false'"/>
 
-    <p:import href="http://www.daisy.org/pipeline/modules/file-utils/library.xpl"/>
     <p:import href="http://www.daisy.org/pipeline/modules/fileset-utils/library.xpl"/>
     <p:import href="http://www.daisy.org/pipeline/modules/common-utils/library.xpl"/>
 

--- a/html-to-dtbook/src/main/resources/xml/html-to-dtbook.xpl
+++ b/html-to-dtbook/src/main/resources/xml/html-to-dtbook.xpl
@@ -23,7 +23,6 @@
         </p:documentation>
     </p:option>
 
-    <p:import href="http://xmlcalabash.com/extension/steps/library-1.0.xpl"/>
     <p:import href="http://www.daisy.org/pipeline/modules/fileset-utils/library.xpl"/>
     <p:import href="http://www.daisy.org/pipeline/modules/html-utils/library.xpl"/>
     <p:import href="html-to-dtbook.convert.xpl"/>

--- a/html-to-epub3/src/main/resources/META-INF/catalog.xml
+++ b/html-to-epub3/src/main/resources/META-INF/catalog.xml
@@ -9,4 +9,5 @@
   <nextCatalog catalog="org:daisy:pipeline:modules:fileset-utils" />
   <nextCatalog catalog="org:daisy:pipeline:modules:mediatype-utils" />
   <nextCatalog catalog="org:daisy:pipeline:modules:common-utils" />
+  <nextCatalog catalog="org:daisy:pipeline:modules:zedai-to-html" />
 </catalog>

--- a/html-to-epub3/src/main/resources/xml/xproc/html-to-epub3.xpl
+++ b/html-to-epub3/src/main/resources/xml/xproc/html-to-epub3.xpl
@@ -38,7 +38,6 @@
     <p:import href="http://www.daisy.org/pipeline/modules/html-utils/library.xpl"/>
     <p:import href="http://www.daisy.org/pipeline/modules/common-utils/library.xpl"/>
     <p:import href="html-to-epub3.convert.xpl"/>
-    <p:import href="http://xmlcalabash.com/extension/steps/library-1.0.xpl"/>
 
     <p:xslt name="output-dir-uri">
         <p:with-param name="href" select="concat($output-dir,'/')">

--- a/zedai-to-epub3/src/main/resources/xml/xproc/zedai-to-epub3.convert.xpl
+++ b/zedai-to-epub3/src/main/resources/xml/xproc/zedai-to-epub3.convert.xpl
@@ -30,7 +30,6 @@
     <p:import href="http://www.daisy.org/pipeline/modules/epub3-ocf-utils/library.xpl"/>
     <p:import href="http://www.daisy.org/pipeline/modules/epub3-pub-utils/library.xpl"/>
     <p:import href="http://www.daisy.org/pipeline/modules/fileset-utils/library.xpl"/>
-    <p:import href="http://xmlcalabash.com/extension/steps/library-1.0.xpl"/>
     <p:import href="http://www.daisy.org/pipeline/modules/common-utils/library.xpl"/>
     <p:import href="http://www.daisy.org/pipeline/modules/ssml-to-audio/library.xpl" />
     <p:import href="http://www.daisy.org/pipeline/modules/mediaoverlay-utils/library.xpl" />

--- a/zedai-to-epub3/src/main/resources/xml/xproc/zedai-to-epub3.xpl
+++ b/zedai-to-epub3/src/main/resources/xml/xproc/zedai-to-epub3.xpl
@@ -51,7 +51,6 @@
     <p:import href="http://www.daisy.org/pipeline/modules/common-utils/library.xpl"/>
     <p:import href="http://www.daisy.org/pipeline/modules/zedai-utils/library.xpl"/>
     <p:import href="http://www.daisy.org/pipeline/modules/css-speech/library.xpl"/>
-    <p:import href="http://xmlcalabash.com/extension/steps/library-1.0.xpl"/>
 
     <p:variable name="input-uri" select="base-uri(/)"/>
 

--- a/zedai-to-html/src/main/resources/META-INF/catalog.xml
+++ b/zedai-to-html/src/main/resources/META-INF/catalog.xml
@@ -11,4 +11,5 @@
    <nextCatalog catalog="org:daisy:pipeline:modules:fileset-utils"/>
    <nextCatalog catalog="org:daisy:pipeline:modules:zedai-utils"/>
    <nextCatalog catalog="org:daisy:pipeline:modules:common-utils"/>
+   <nextCatalog catalog="org:daisy:pipeline:modules:html-utils"/>
 </catalog>

--- a/zedai-to-html/src/main/resources/xml/xproc/zedai-to-html.convert.xpl
+++ b/zedai-to-html/src/main/resources/xml/xproc/zedai-to-html.convert.xpl
@@ -22,7 +22,6 @@
 
     <p:import href="http://www.daisy.org/pipeline/modules/fileset-utils/library.xpl"/>
     <p:import href="http://www.daisy.org/pipeline/modules/common-utils/library.xpl"/>
-    <p:import href="http://xmlcalabash.com/extension/steps/library-1.0.xpl"/>
 
     <!--=========================================================================-->
     <!-- GET ZEDAI FROM FILESET                                                  -->

--- a/zedai-to-html/src/main/resources/xml/xproc/zedai-to-html.xpl
+++ b/zedai-to-html/src/main/resources/xml/xproc/zedai-to-html.xpl
@@ -25,7 +25,6 @@
     <p:import href="zedai-to-html.convert.xpl"/>
     <p:import href="http://www.daisy.org/pipeline/modules/zedai-utils/library.xpl"/>
     <p:import href="http://www.daisy.org/pipeline/modules/fileset-utils/library.xpl"/>
-    <p:import href="http://xmlcalabash.com/extension/steps/library-1.0.xpl"/>
     
     <p:variable name="input-uri" select="base-uri(/)"/>
     


### PR DESCRIPTION
I did a quick scan through and removed unused module dependencies and added missing module dependencies from the XML catalogs.

Also started using `px:fileset-create` in dtbook-validator so that the base of the fileset is set properly.

see also (can be merged separately):
daisy/pipeline-modules-common#80
daisy/pipeline-scripts-utils#75
daisy/pipeline-scripts#83
daisy/pipeline-mod-braille#14
daisy/pipeline-mod-tts#52

<!---
@huboard:{"order":97.0,"milestone_order":83.0,"custom_state":""}
-->
