### PR TITLE
added input-filesets and output-filesets to scripts

### DIFF
--- a/daisy202-to-epub3/src/main/resources/xml/daisy202-to-epub3.xpl
+++ b/daisy202-to-epub3/src/main/resources/xml/daisy202-to-epub3.xpl
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:px="http://www.daisy.org/ns/pipeline/xproc" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cx="http://xmlcalabash.com/ns/extensions"
-    xmlns:pxi="http://www.daisy.org/ns/pipeline/xproc/internal" xmlns:html="http://www.w3.org/1999/xhtml" type="px:daisy202-to-epub3" version="1.0">
+    xmlns:pxi="http://www.daisy.org/ns/pipeline/xproc/internal" xmlns:html="http://www.w3.org/1999/xhtml"
+    px:input-filesets="daisy202"
+    px:output-filesets="epub3"
+    type="px:daisy202-to-epub3" version="1.0">
 
     <p:documentation xmlns="http://www.w3.org/1999/xhtml">
         <h1 px:role="name">DAISY 2.02 to EPUB3</h1>

--- a/daisy202-validator/src/main/resources/xml/xproc/daisy202-validator.xpl
+++ b/daisy202-validator/src/main/resources/xml/xproc/daisy202-validator.xpl
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:px="http://www.daisy.org/ns/pipeline/xproc" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cx="http://xmlcalabash.com/ns/extensions"
-    xmlns:pxi="http://www.daisy.org/ns/pipeline/xproc/internal" xmlns:html="http://www.w3.org/1999/xhtml" type="px:daisy202-validator" version="1.0" xmlns:d="http://www.daisy.org/ns/pipeline/data">
+    xmlns:pxi="http://www.daisy.org/ns/pipeline/xproc/internal" xmlns:html="http://www.w3.org/1999/xhtml" type="px:daisy202-validator" version="1.0"
+    px:input-filesets="daisy202"
+    xmlns:d="http://www.daisy.org/ns/pipeline/data">
 
     <p:documentation xmlns="http://www.w3.org/1999/xhtml">
         <h1 px:role="name">DAISY 2.02 Validator</h1>

--- a/daisy3-to-epub3/src/main/resources/xml/xproc/daisy3-to-epub3.xpl
+++ b/daisy3-to-epub3/src/main/resources/xml/xproc/daisy3-to-epub3.xpl
@@ -2,6 +2,8 @@
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
     xmlns:px="http://www.daisy.org/ns/pipeline/xproc" xmlns:dc="http://purl.org/dc/elements/1.1/"
     xmlns:pxi="http://www.daisy.org/ns/pipeline/xproc/internal/daisy3-to-epub3"
+    px:input-filesets="daisy3"
+    px:output-filesets="epub3"
     type="px:daisy3-to-epub3" version="1.0" name="main">
 
     <p:documentation xmlns="http://www.w3.org/1999/xhtml">

--- a/dtbook-to-daisy3/src/main/resources/xml/dtbook-to-daisy3.xpl
+++ b/dtbook-to-daisy3/src/main/resources/xml/dtbook-to-daisy3.xpl
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <p:declare-step version="1.0" name="dtbook-to-daisy3" type="px:dtbook-to-daisy3"
+    px:input-filesets="dtbook"
+    px:output-filesets="daisy3 mp3"
 		xmlns:p="http://www.w3.org/ns/xproc"
 		xmlns:px="http://www.daisy.org/ns/pipeline/xproc"
 		xmlns:dtbook="http://www.daisy.org/z3986/2005/dtbook/"

--- a/dtbook-to-epub3/src/main/resources/xml/dtbook-to-epub3.xpl
+++ b/dtbook-to-epub3/src/main/resources/xml/dtbook-to-epub3.xpl
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<p:declare-step version="1.0" name="dtbook-to-epub3" type="px:dtbook-to-epub3" xmlns:p="http://www.w3.org/ns/xproc" xmlns:c="http://www.w3.org/ns/xproc-step"
+<p:declare-step version="1.0" name="dtbook-to-epub3" type="px:dtbook-to-epub3"
+    px:input-filesets="dtbook"
+    px:output-filesets="epub3"
+    xmlns:p="http://www.w3.org/ns/xproc" xmlns:c="http://www.w3.org/ns/xproc-step"
     xmlns:px="http://www.daisy.org/ns/pipeline/xproc" xmlns:pxi="http://www.daisy.org/ns/pipeline/xproc/internal" xmlns:tmp="http://www.daisy.org/ns/pipeline/tmp"
     xmlns:z="http://www.daisy.org/ns/z3986/authoring/" xmlns:dtbook="http://www.daisy.org/z3986/2005/dtbook/" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:d="http://www.daisy.org/ns/pipeline/data" exclude-inline-prefixes="#all">
 

--- a/dtbook-to-html/src/main/resources/xml/dtbook-to-html.xpl
+++ b/dtbook-to-html/src/main/resources/xml/dtbook-to-html.xpl
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <p:declare-step version="1.0" name="main" type="px:dtbook-to-html"
+    px:input-filesets="dtbook"
+    px:output-filesets="html"
     xmlns:p="http://www.w3.org/ns/xproc" xmlns:c="http://www.w3.org/ns/xproc-step"
     xmlns:px="http://www.daisy.org/ns/pipeline/xproc"
     xmlns:pxi="http://www.daisy.org/ns/pipeline/xproc/internal"

--- a/dtbook-to-odt/src/main/resources/xml/dtbook-to-odt.xpl
+++ b/dtbook-to-odt/src/main/resources/xml/dtbook-to-odt.xpl
@@ -7,6 +7,8 @@
     xmlns:odt="urn:oasis:names:tc:opendocument:xmlns:text:1.0"
     xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0"
     exclude-inline-prefixes="#all"
+    px:input-filesets="dtbook"
+    px:output-filesets="odt"
     type="px:dtbook-to-odt" name="dtbook-to-odt" version="1.0">
     
     <p:documentation xmlns="http://www.w3.org/1999/xhtml">

--- a/dtbook-to-zedai/src/main/resources/xml/dtbook-to-zedai.xpl
+++ b/dtbook-to-zedai/src/main/resources/xml/dtbook-to-zedai.xpl
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<p:declare-step version="1.0" name="dtbook-to-zedai" type="px:dtbook-to-zedai" xmlns:p="http://www.w3.org/ns/xproc" xmlns:c="http://www.w3.org/ns/xproc-step"
+<p:declare-step version="1.0" name="dtbook-to-zedai" type="px:dtbook-to-zedai"
+    px:input-filesets="dtbook"
+    px:output-filesets="zedai"
+    xmlns:p="http://www.w3.org/ns/xproc" xmlns:c="http://www.w3.org/ns/xproc-step"
     xmlns:px="http://www.daisy.org/ns/pipeline/xproc"
     exclude-inline-prefixes="#all">
 

--- a/dtbook-validator/src/main/resources/xml/dtbook-validator.xpl
+++ b/dtbook-validator/src/main/resources/xml/dtbook-validator.xpl
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <p:declare-step version="1.0" name="dtbook-validator" type="px:dtbook-validator"
+    px:input-filesets="dtbook"
     xmlns:p="http://www.w3.org/ns/xproc" xmlns:c="http://www.w3.org/ns/xproc-step"
     xmlns:px="http://www.daisy.org/ns/pipeline/xproc"
     xmlns:pxi="http://www.daisy.org/ns/pipeline/xproc/internal"

--- a/epub3-to-daisy202/src/main/resources/xml/xproc/epub3-to-daisy202.xpl
+++ b/epub3-to-daisy202/src/main/resources/xml/xproc/epub3-to-daisy202.xpl
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:c="http://www.w3.org/ns/xproc-step" xmlns:px="http://www.daisy.org/ns/pipeline/xproc" xmlns:d="http://www.daisy.org/ns/pipeline/data"
+    px:input-filesets="epub3"
+    px:output-filesets="daisy202"
     type="px:epub3-to-daisy202" name="main" version="1.0" xmlns:epub="http://www.idpf.org/2007/ops" xmlns:pxp="http://exproc.org/proposed/steps" xpath-version="2.0">
 
     <p:documentation xmlns="http://www.w3.org/1999/xhtml">

--- a/epub3-validator/src/main/resources/xml/xproc/epub3-validator.xpl
+++ b/epub3-validator/src/main/resources/xml/xproc/epub3-validator.xpl
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:px="http://www.daisy.org/ns/pipeline/xproc" xmlns:dc="http://purl.org/dc/elements/1.1/"
-    xmlns:pxi="http://www.daisy.org/ns/pipeline/xproc/internal" xmlns:html="http://www.w3.org/1999/xhtml" type="px:epub3-validator" version="1.0" xmlns:d="http://www.daisy.org/ns/pipeline/data">
+<p:declare-step type="px:epub3-validator" version="1.0"
+    px:input-filesets="epub3"
+    xmlns:p="http://www.w3.org/ns/xproc" xmlns:px="http://www.daisy.org/ns/pipeline/xproc" xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:pxi="http://www.daisy.org/ns/pipeline/xproc/internal" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:d="http://www.daisy.org/ns/pipeline/data">
 
     <p:documentation xmlns="http://www.w3.org/1999/xhtml">
         <h1 px:role="name">EPUB3 Validator</h1>

--- a/html-to-dtbook/src/main/resources/xml/html-to-dtbook.xpl
+++ b/html-to-dtbook/src/main/resources/xml/html-to-dtbook.xpl
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<p:declare-step version="1.0" name="html-to-dtbook" type="px:html-to-dtbook" xmlns:p="http://www.w3.org/ns/xproc" xmlns:c="http://www.w3.org/ns/xproc-step"
+<p:declare-step version="1.0" name="html-to-dtbook" type="px:html-to-dtbook"
+    px:input-filesets="html"
+    px:output-filesets="dtbook"
+    xmlns:p="http://www.w3.org/ns/xproc" xmlns:c="http://www.w3.org/ns/xproc-step"
     xmlns:px="http://www.daisy.org/ns/pipeline/xproc" xmlns:pxi="http://www.daisy.org/ns/pipeline/xproc/internal" xmlns:tmp="http://www.daisy.org/ns/pipeline/tmp" xmlns:d="http://www.daisy.org/ns/pipeline/data"
     xmlns:html="http://www.w3.org/1999/xhtml" xpath-version="2.0" exclude-inline-prefixes="#all">
 

--- a/html-to-epub3/src/main/resources/xml/xproc/html-to-epub3.xpl
+++ b/html-to-epub3/src/main/resources/xml/xproc/html-to-epub3.xpl
@@ -2,6 +2,8 @@
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:c="http://www.w3.org/ns/xproc-step"
     xmlns:px="http://www.daisy.org/ns/pipeline/xproc"
     xmlns:d="http://www.daisy.org/ns/pipeline/data"
+    px:input-filesets="html"
+    px:output-filesets="epub3"
     type="px:html-to-epub3" name="main" version="1.0">
 
     <p:documentation xmlns="http://www.w3.org/1999/xhtml">

--- a/nimas-fileset-validator/src/main/resources/xml/nimas-fileset-validator.xpl
+++ b/nimas-fileset-validator/src/main/resources/xml/nimas-fileset-validator.xpl
@@ -9,6 +9,7 @@
     xmlns:m="http://www.w3.org/1998/Math/MathML" xmlns:px="http://www.daisy.org/ns/pipeline/xproc"
     xmlns:p="http://www.w3.org/ns/xproc" xmlns:tmp="http://www.daisy.org/ns/pipeline/tmp"
     version="1.0" name="nimas-fileset-validator" type="px:nimas-fileset-validator"
+    px:input-filesets="nimas dtbook daisy3"
     exclude-inline-prefixes="#all">
 
     <p:documentation xmlns="http://www.w3.org/1999/xhtml">

--- a/pom.xml
+++ b/pom.xml
@@ -20,22 +20,22 @@
 
   <!-- List of the modules to build all-at-once -->
   <modules>
-    <!-- <module>daisy202-to-epub3</module> -->
-    <!-- <module>daisy202-validator</module> -->
-    <!-- <module>daisy3-to-epub3</module> -->
+    <module>daisy202-to-epub3</module>
+    <module>daisy202-validator</module>
+    <module>daisy3-to-epub3</module>
     <module>dtbook-to-daisy3</module>
-    <!-- <module>dtbook-to-epub3</module> -->
-    <!-- <module>dtbook-to-html</module> -->
-    <!-- <module>dtbook-to-odt</module> -->
-    <!-- <module>dtbook-to-zedai</module> -->
-    <!-- <module>dtbook-validator</module> -->
-    <!-- <module>epub3-validator</module> -->
-    <!-- <module>epub3-to-daisy202</module> -->
-    <!-- <module>html-to-dtbook</module> -->
-    <!-- <module>html-to-epub3</module> -->
-    <!-- <module>nimas-fileset-validator</module> -->
+    <module>dtbook-to-epub3</module>
+    <module>dtbook-to-html</module>
+    <module>dtbook-to-odt</module>
+    <module>dtbook-to-zedai</module>
+    <module>dtbook-validator</module>
+    <module>epub3-validator</module>
+    <module>epub3-to-daisy202</module>
+    <module>html-to-dtbook</module>
+    <module>html-to-epub3</module>
+    <module>nimas-fileset-validator</module>
     <module>zedai-to-epub3</module>
-    <!-- <module>zedai-to-html</module> -->
+    <module>zedai-to-html</module>
   </modules>
 
   <!-- BoM of the default script modules (for use in assemblies) -->
@@ -44,17 +44,17 @@
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>
         <artifactId>daisy202-to-epub3</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>
         <artifactId>daisy202-validator</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>
         <artifactId>daisy3-to-epub3</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>
@@ -64,32 +64,32 @@
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>
         <artifactId>dtbook-to-epub3</artifactId>
-        <version>1.2.0</version>
+        <version>1.2.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>
         <artifactId>dtbook-to-html</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>
         <artifactId>dtbook-to-odt</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>
         <artifactId>dtbook-to-zedai</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>
         <artifactId>dtbook-validator</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>
         <artifactId>epub3-to-daisy202</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1-SNAPSHOT</version>
       </dependency>
       <!-- <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>
@@ -104,12 +104,12 @@
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>
         <artifactId>html-to-epub3</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>
         <artifactId>nimas-fileset-validator</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>
@@ -119,7 +119,7 @@
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>
         <artifactId>zedai-to-html</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3-SNAPSHOT</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/zedai-to-epub3/src/main/resources/xml/xproc/zedai-to-epub3.xpl
+++ b/zedai-to-epub3/src/main/resources/xml/xproc/zedai-to-epub3.xpl
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:c="http://www.w3.org/ns/xproc-step" xmlns:px="http://www.daisy.org/ns/pipeline/xproc" xmlns:d="http://www.daisy.org/ns/pipeline/data"
+    px:input-filesets="zedai"
+    px:output-filesets="epub3 mp3"
     type="px:zedai-to-epub3" name="zedai-to-epub3" version="1.0">
 
     <p:documentation xmlns="http://www.w3.org/1999/xhtml">

--- a/zedai-to-html/src/main/resources/xml/xproc/zedai-to-html.xpl
+++ b/zedai-to-html/src/main/resources/xml/xproc/zedai-to-html.xpl
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:c="http://www.w3.org/ns/xproc-step" xmlns:px="http://www.daisy.org/ns/pipeline/xproc"
     xmlns:d="http://www.daisy.org/ns/pipeline/data"
+    px:input-filesets="zedai"
+    px:output-filesets="html"
     type="px:zedai-to-html" name="main" version="1.0">
 
     <p:documentation xmlns="http://www.w3.org/1999/xhtml">


### PR DESCRIPTION
For scripts where those attributes are missing, they could potentially
be inferred by matching the conventions `[input-fileset]-to-[output-fileset]`
and `[input-fileset]-validator`. I might do that in the Web UI, but it might
be useful to put that logic into the engine at some point (low priority).

Validator scripts could potentially have `px:output-filesets="html"`, I dunno...

<!---
@huboard:{"milestone_order":87.0,"order":98.0,"custom_state":""}
-->
