### PR TITLE
Nimas

### DIFF
--- a/dtbook-validator/src/main/resources/xml/dtbook-validator.validate.xpl
+++ b/dtbook-validator/src/main/resources/xml/dtbook-validator.validate.xpl
@@ -157,14 +157,16 @@
     
     <p:choose name="choose-schematron">
         <p:when test="$nimas = 'true'">
-            <p:identity>
+            <p:output port="result"/>
+            <p:identity name="use-nimas-schematron">
                 <p:input port="source">
                     <p:document href="./schema/sch/dtbook.mathml.nimas.sch"/>
                 </p:input>
             </p:identity>
         </p:when>
         <p:otherwise>
-            <p:identity>
+            <p:output port="result"/>
+            <p:identity name="use-default-schematron">
                 <p:input port="source">
                     <p:document href="./schema/sch/dtbook.mathml.sch"/>
                 </p:input>
@@ -174,7 +176,7 @@
     <!-- validate with schematron --> 
     <p:validate-with-schematron assert-valid="false" name="validate-against-schematron">
         <p:input port="schema">
-            <p:pipe step="choose-schematron" port="result"/>
+            <p:pipe port="result" step="choose-schematron"/>
         </p:input>
         <p:input port="source">
             <p:pipe port="source" step="dtbook-validator.validate"/>

--- a/dtbook-validator/src/main/resources/xml/dtbook-validator.validate.xpl
+++ b/dtbook-validator/src/main/resources/xml/dtbook-validator.validate.xpl
@@ -63,6 +63,7 @@
     <p:option name="mathml-version"/>
     <p:option name="check-images"/>
     <p:option name="base-uri"/>
+    <p:option name="nimas"/>
     
     <p:import href="http://www.daisy.org/pipeline/modules/common-utils/library.xpl"/>
     
@@ -153,10 +154,27 @@
         </p:choose>
     </p:group>
     
-    <!-- validate with schematron -->
+    
+    <p:choose name="choose-schematron">
+        <p:when test="$nimas = 'true'">
+            <p:identity>
+                <p:input port="source">
+                    <p:document href="./schema/sch/dtbook.mathml.nimas.sch"/>
+                </p:input>
+            </p:identity>
+        </p:when>
+        <p:otherwise>
+            <p:identity>
+                <p:input port="source">
+                    <p:document href="./schema/sch/dtbook.mathml.sch"/>
+                </p:input>
+            </p:identity>
+        </p:otherwise>
+    </p:choose>
+    <!-- validate with schematron --> 
     <p:validate-with-schematron assert-valid="false" name="validate-against-schematron">
         <p:input port="schema">
-            <p:document href="./schema/sch/dtbook.mathml.sch"/>
+            <p:pipe step="choose-schematron" port="result"/>
         </p:input>
         <p:input port="source">
             <p:pipe port="source" step="dtbook-validator.validate"/>

--- a/dtbook-validator/src/main/resources/xml/dtbook-validator.xpl
+++ b/dtbook-validator/src/main/resources/xml/dtbook-validator.xpl
@@ -91,6 +91,13 @@
         </p:documentation>
     </p:option>
 
+    <p:option name="nimas" required="false" px:type="boolean" select="'false'">
+        <p:documentation xmlns="http://www.w3.org/1999/xhtml">
+            <h2 px:role="name">Validate against NIMAS 1.1</h2>
+            <p px:role="desc">Validate using NIMAS 1.1 rules for DTBook.</p>
+        </p:documentation>
+    </p:option>
+    
     <p:import href="http://www.daisy.org/pipeline/modules/common-utils/library.xpl"/>
 
     <p:import
@@ -169,6 +176,7 @@
                 <p:with-option name="mathml-version" select="$mathml-version"/>
                 <p:with-option name="check-images" select="$check-images"/>
                 <p:with-option name="base-uri" select="$input-dtbook"/>
+                <p:with-option name="nimas" select="$nimas"/>
             </pxi:dtbook-validator.validate>
 
             <pxi:dtbook-validator.store name="store-dtbook-validation-results">

--- a/dtbook-validator/src/main/resources/xml/schema/sch/dtbook.mathml.nimas.sch
+++ b/dtbook-validator/src/main/resources/xml/schema/sch/dtbook.mathml.nimas.sch
@@ -24,6 +24,8 @@
     <!-- ****************************************************** -->
     <!-- Patterns in this section were imported from Pipeline 1 -->
     <!-- ****************************************************** -->
+
+
     <!-- removing these rules for NIMAS compliance (requested by APH) -->
     <!--
     <pattern id="dtbook_MetaUid">
@@ -48,6 +50,14 @@
         </rule>
     </pattern>
 -->
+    
+    <!-- added for NIMAS -->
+    <pattern id="dtbook_NimasHeadMeta">
+        <rule context="dtb:meta">
+            <assert test="count(*) &gt; 0">The meta element must be empty.</assert>
+        </rule>
+    </pattern>
+    
     <pattern id="dtbook_idrefNote">
         <rule context="dtb:noteref">
             <assert test="contains(@idref, '#')"> noteref URI value does not contain a fragment

--- a/dtbook-validator/src/main/resources/xml/schema/sch/dtbook.mathml.nimas.sch
+++ b/dtbook-validator/src/main/resources/xml/schema/sch/dtbook.mathml.nimas.sch
@@ -1,0 +1,314 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2"
+    xmlns:dtb="http://www.daisy.org/z3986/2005/dtbook/" xmlns:m="http://www.w3.org/1998/Math/MathML"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <ns uri="http://www.daisy.org/z3986/2005/dtbook/" prefix="dtb"/>
+    <ns uri="http://www.w3.org/1998/Math/MathML" prefix="m"/>
+
+    <xsl:key name="notes" match="dtb:note[@id]" use="@id"/>
+    <xsl:key name="annotations" match="dtb:annotation[@id]" use="@id"/>
+
+    <!-- 
+        because we override the ID datatype with NMTOKEN in the dtbook-mathml-integration schema,
+        we need to double check that all @id values are unique
+    -->
+    <pattern id="id-unique">
+        <let name="id-set" value="//*[@id]"/>
+        <rule context="*[@id]">
+            <assert test="count($id-set[@id = current()/@id]) = 1">Duplicate ID '<value-of
+                    select="current()/@id"/>'</assert>
+        </rule>
+    </pattern>
+
+    <!-- ****************************************************** -->
+    <!-- Patterns in this section were imported from Pipeline 1 -->
+    <!-- ****************************************************** -->
+    <!-- removing these rules for NIMAS compliance (requested by APH) -->
+    <!--
+    <pattern id="dtbook_MetaUid">
+        <rule context="dtb:head">
+            <assert test="count(dtb:meta[@name='dtb:uid'])=1"> There must be exactly one
+                dtb:uid metadata item. </assert>
+        </rule>
+        <rule context="dtb:meta[@name='dtb:uid']">
+            <assert test="string-length(normalize-space(@content))!=0"> Content of dtb:uid metadata
+                may not be empty. </assert>
+        </rule>
+    </pattern>
+
+    <pattern id="dtbook_MetaTitle">
+        <rule context="dtb:head">
+            <assert test="count(dtb:meta[@name='dc:Title'])>0"> There must be at least one dc:Title
+                metadata item. </assert>
+        </rule>
+        <rule context="dtb:meta[@name='dc:Title']">
+            <assert test="string-length(normalize-space(@content))!=0"> Content of dc:Title metadata
+                may not be empty. </assert>
+        </rule>
+    </pattern>
+-->
+    <pattern id="dtbook_idrefNote">
+        <rule context="dtb:noteref">
+            <assert test="contains(@idref, '#')"> noteref URI value does not contain a fragment
+                identifier. </assert>
+            <report
+                test="contains(@idref, '#') and string-length(substring-before(@idref, '#'))=0 and count(key('notes',substring(current()/@idref,2)))!=1"
+                > noteref URI value does not resolve to a note element. </report>
+            <!-- Do not perform any checks on external note references since you cannot set a URIResolver in Jing
+	       <sch:report test="string-length(substring-before(@idref, '#'))>0 and not(document(substring-before(@idref, '#')))">External document does not exist</sch:report>
+	       <sch:report test="string-length(substring-before(@idref, '#'))>0 and count(document(substring-before(@idref, '#'))//dtb:note[@id=substring-after(current()/@idref, '#')])!=1">Incorrect external fragment identifier</sch:report>
+	        -->
+        </rule>
+    </pattern>
+
+    <pattern id="dtbook_idrefAnnotation">
+        <rule context="dtb:annoref">
+            <assert test="contains(@idref, '#')"> annoref URI value does not contain a fragment
+                identifier. </assert>
+            <report
+                test="contains(@idref, '#') and string-length(substring-before(@idref, '#'))=0 and count(key('annotations',substring(current()/@idref,2)))!=1"
+                > annoref URI value does not resolve to a annotation element. </report>
+            <!-- Do not perform any checks on external note references since you cannot set a URIResolver in Jing
+	        <sch:report test="string-length(substring-before(@idref, '#'))>0 and not(document(substring-before(@idref, '#')))">External document does not exist</sch:report>
+	        <sch:report test="string-length(substring-before(@idref, '#'))>0 and count(document(substring-before(@idref, '#'))//dtb:annotation[@id=substring-after(current()/@idref, '#')])!=1">Incorrect external fragment identifier</sch:report>
+	        -->
+        </rule>
+    </pattern>
+
+    <pattern id="dtbook_internalLinks">
+        <rule context="dtb:a[starts-with(@href, '#')]">
+            <assert test="count(//dtb:*[@id=substring(current()/@href, 2)])=1"> Internal link does
+                not resolve. </assert>
+        </rule>
+    </pattern>
+
+    <!-- MG20061101: added as a consequence of zedval feature request #1565049 -->
+    <pattern id="dtbook_enumAttrInList">
+        <rule context="dtb:list">
+            <report test="@enum and @type!='ol'"> The enum attribute is only allowed in numbered
+                lists. </report>
+        </rule>
+    </pattern>
+
+    <!-- MG20061101: added as a consequence of zedval feature request #1565049 -->
+    <pattern id="dtbook_depthList">
+        <rule context="dtb:list">
+            <report test="@depth and @depth!=count(ancestor-or-self::dtb:list)"> The depth attribute
+                on list element does not contain the list wrapping level. </report>
+        </rule>
+    </pattern>
+
+    <!-- MG20061101: added as a consequence of zedval feature request #1565049 -->
+    <pattern id="dtbook_headersThTd">
+        <rule context="dtb:*[@headers and (self::dtb:th or self::dtb:td)]">
+            <assert
+                test="
+                count(
+                ancestor::dtb:table//dtb:th/@id[contains( concat(' ',current()/@headers,' '), concat(' ',normalize-space(),' ') )]
+                ) = 
+                string-length(normalize-space(@headers)) - string-length(translate(normalize-space(@headers), ' ','')) + 1
+                "
+                > Not all the tokens in the headers attribute match the id attributes of 'th'
+                elements in this or a parent table. </assert>
+        </rule>
+    </pattern>
+
+    <!-- MG20061101: added as a consequence of zedval feature request #1565049 -->
+    <pattern id="dtbook_imgrefProdnote">
+        <rule context="dtb:prodnote[@imgref]">
+            <assert
+                test="
+                count(
+                //dtb:img/@id[contains( concat(' ',current()/@imgref,' '), concat(' ',normalize-space(),' ') )]
+                ) = 
+                string-length(normalize-space(@imgref)) - string-length(translate(normalize-space(@imgref), ' ','')) + 1
+                "
+                > Not all the tokens in the imgref attribute match the id attributes of 'img'
+                elements. </assert>
+        </rule>
+    </pattern>
+
+    <!-- MG20061101: added as a consequence of zedval feature request #1565049 -->
+    <pattern id="dtbook_imgrefCaption">
+        <rule context="dtb:caption[@imgref]">
+            <assert
+                test="
+                count(
+                //dtb:img/@id[contains( concat(' ',current()/@imgref,' '), concat(' ',normalize-space(),' ') )]
+                ) = 
+                string-length(normalize-space(@imgref)) - string-length(translate(normalize-space(@imgref), ' ','')) + 1
+                "
+                > Not all the tokens in the imgref attribute match the id attributes of 'img'
+                elements. </assert>
+        </rule>
+    </pattern>
+
+    <!-- MG20061101: added as a consequence of zedval feature request #1565049 -->
+    <pattern id="dtbook_accesskeyTabindex">
+        <rule context="dtb:a">
+            <report test="@accesskey and string-length(@accesskey)!=1">The accesskey attribute value
+                is not 1 character long.</report>
+            <report test="@tabindex and string-length(translate(@width,'0123456789',''))!=0">The
+                tabindex attribute value is not expressed in numbers.</report>
+            <report test="@accesskey and count(//dtb:a/@accesskey=@accesskey)!=1">The accesskey
+                attribute value is not unique within the document.</report>
+            <report test="@tabindex and count(//dtb:a/@tabindex=@tabindex)!=1">The tabindex
+                attribute value is not unique within the document.</report>
+        </rule>
+    </pattern>
+
+    <!-- MG20061101: added as a consequence of zedval feature request #1565049 -->
+    <pattern id="dtbook_charAttribute">
+        <rule
+            context="dtb:*[self::dtb:col   or self::dtb:colgroup or self::dtb:tbody or self::dtb:td or 
+            self::dtb:tfoot or self::dtb:th       or self::dtb:thead or self::dtb:tr]">
+            <report test="@char and string-length(@char)!=1">The char attribute value is not 1
+                character long.</report>
+            <report test="@char and @align!='char'">char attribute may only occur when align
+                attribute value is 'char'.</report>
+        </rule>
+    </pattern>
+
+    <!-- MG20061101: added as a consequence of zedval feature request #1565049 -->
+    <pattern id="dtbook_imgWidthHeight">
+        <rule context="dtb:img">
+            <assert
+                test="not(@width) or 
+                string-length(translate(@width,'0123456789',''))=0 or
+                (contains(@width,'%') and substring-after(@width,'%')='' and translate(@width,'%0123456789','')='' and string-length(@width)>=2)"
+                >The image width is not expressed in pixels or percentage.</assert>
+            <assert
+                test="not(@height) or 
+                string-length(translate(@height,'0123456789',''))=0 or
+                (contains(@height,'%') and substring-after(@height,'%')='' and translate(@height,'%0123456789','')='' and string-length(@height)>=2)"
+                >The image height is not expressed in pixels or percentage.</assert>
+        </rule>
+    </pattern>
+
+    <!-- MG20061101: added as a consequence of zedval feature request #1565049 -->
+    <pattern id="dtbook_tableAttributes">
+        <rule context="dtb:table">
+            <assert
+                test="not(@width) or 
+                string-length(translate(@width,'0123456789',''))=0 or
+                (contains(@width,'%') and substring-after(@width,'%')='' and translate(@width,'%0123456789','')='' and string-length(@width)>=2)"
+                >Table width is not expressed in pixels or percentage.</assert>
+            <assert
+                test="not(@cellspacing) or 
+                string-length(translate(@cellspacing,'0123456789',''))=0 or
+                (contains(@cellspacing,'%') and substring-after(@cellspacing,'%')='' and translate(@cellspacing,'%0123456789','')='' and string-length(@cellspacing)>=2)"
+                >Table cellspacing is not expressed in pixels or percentage.</assert>
+            <assert
+                test="not(@cellpadding) or 
+                string-length(translate(@cellpadding,'0123456789',''))=0 or
+                (contains(@cellpadding,'%') and substring-after(@cellpadding,'%')='' and translate(@cellpadding,'%0123456789','')='' and string-length(@cellpadding)>=2)"
+                >Table cellpadding is not expressed in pixels or percentage.</assert>
+        </rule>
+    </pattern>
+
+    <!-- MG20061101: added as a consequence of zedval feature request #1565049 -->
+    <pattern id="dtbook_startAttrInList">
+        <rule context="dtb:list">
+            <report test="@start and @type!='ol'">The start attribute occurs in a non-numbered
+                list.</report>
+            <report test="@start='' or string-length(translate(@start,'0123456789',''))!=0">The
+                start attribute is not a non negative number.</report>
+        </rule>
+    </pattern>
+
+    <!-- MG20061101: added as a consequence of zedval feature request #1565049 -->
+    <pattern id="dtbook_dcMetadata">
+        <rule context="dtb:meta">
+            <report
+                test="starts-with(@name, 'dc:') and not(@name='dc:Title' or @name='dc:Subject' or @name='dc:Description' or
+                @name='dc:Type' or @name='dc:Source' or @name='dc:Relation' or 
+                @name='dc:Coverage' or @name='dc:Creator' or @name='dc:Publisher' or 
+                @name='dc:Contributor' or @name='dc:Rights' or @name='dc:Date' or 
+                @name='dc:Format' or @name='dc:Identifier' or @name='dc:Language')"
+                >Unrecognized Dublin Core metadata name.</report>
+            <report
+                test="starts-with(@name, 'DC:') or starts-with(@name, 'Dc:') or starts-with(@name, 'dC:')"
+                >Unrecognized Dublin Core metadata prefix.</report>
+        </rule>
+    </pattern>
+
+    <!-- MG20061101: added as a consequence of zedval feature request #1565049 -->
+    <pattern id="dtbook_spanColColgroup">
+        <rule context="dtb:*[self::dtb:col or self::dtb:colgroup]">
+            <report
+                test="@span and (translate(@span,'0123456789','')!='' or starts-with(@span,'0'))"
+                >span attribute is not a positive integer.</report>
+        </rule>
+    </pattern>
+
+    <!-- MG20061101: added as a consequence of zedval feature request #1565049 -->
+    <pattern>
+        <rule context="dtb:*[self::dtb:td or self::dtb:th]">
+            <report
+                test="@rowspan and (translate(@rowspan,'0123456789','')!='' or starts-with(@rowspan,'0'))"
+                > The rowspan attribute value is not a positive integer.</report>
+            <report
+                test="@colspan and (translate(@colspan,'0123456789','')!='' or starts-with(@colspan,'0'))"
+                > The colspan attribute value is not a positive integer.</report>
+            <report
+                test="@rowspan and number(@rowspan) > count(parent::dtb:tr/following-sibling::dtb:tr)+1"
+                > The rowspan attribute value is larger than the number of rows left in the
+                table.</report>
+        </rule>
+    </pattern>
+
+    <!-- MG20070522: added as a consequence of zedval feature request #1593192 -->
+    <pattern id="dtbook_levelDepth">
+        <rule context="dtb:level[@depth]">
+            <assert test="@depth=count(ancestor-or-self::dtb:level)">The value of the depth
+                attribute on the level element does not correspond to actual nesting level.</assert>
+        </rule>
+    </pattern>
+
+    <!-- ****************************************************** -->
+    <!-- end Pipeline 1 pattern imports -->
+    <!-- ****************************************************** -->
+
+    <!-- 
+        The math element has optional attributes alttext and altimg. To be valid with the MathML in DAISY spec, 
+        the alttext and altimg attributes must be part of the math element.
+    -->
+    <pattern>
+        <rule context="//m:math">
+            <assert test="//node()[@alttext]">alttext attribute must be present</assert>
+            <assert test="not(empty(//node()[@alttext]))">alttext attribute must be
+                non-empty</assert>
+
+            <assert test="//node()[@altimg]">altimg attribute must be present</assert>
+            <assert test="not(empty(//node()[@altimg]))">altimg attribute must be non-empty</assert>
+
+            <!-- Note that there is not a test for the rule 
+                "@smilref may be present and if so must be non-empty"
+                because this is designed to be used with standalone DTBook files
+            -->
+        </rule>
+    </pattern>
+
+    <!-- because we override the IDREF datatype with NMTOKEN in the dtbook-mathml-integration schema,
+        we need to double check MathML @xref values (which were originally of type IDREF)
+        
+        Note that we don't need to perform these checks on DTBook elements because of the 
+        Pipeline 1 patterns here that look at annoref and noteref already, which are the only 2 elements
+        to use an attribute originally of the type IDREF.
+    -->
+    <pattern id="xref">
+        <rule context="m:*[@xref]">
+            <assert test="some $elem in //* satisfies ($elem/@id eq @xref)"> xref attribute does not
+                resolve.</assert>
+        </rule>
+    </pattern>
+
+    <pattern id="annotation">
+        <rule context="m:annotation-xml">
+            <assert test="node()/ancestor::m:semantics"> </assert>
+        </rule>
+    </pattern>
+
+    <include href="mod/mathml-content-elements.sch"/>
+</schema>

--- a/nimas-fileset-validator/src/main/resources/xml/nimas-fileset-validator.validate.xpl
+++ b/nimas-fileset-validator/src/main/resources/xml/nimas-fileset-validator.validate.xpl
@@ -112,6 +112,7 @@
                 <p:with-option name="input-dtbook" select="$dtbook-href"/>
                 <p:with-option name="check-images" select="$check-images"/>
                 <p:with-option name="mathml-version" select="$mathml-version"/>
+                <p:with-option name="nimas" select="'true'"/>
             </px:dtbook-validator>
 
             <!-- add the report path -->

--- a/nimas-fileset-validator/src/main/resources/xml/schema/sch/mod/package-doc-common.sch
+++ b/nimas-fileset-validator/src/main/resources/xml/schema/sch/mod/package-doc-common.sch
@@ -2,7 +2,15 @@
 	<let name="uniqueid" value="//pkg:package/@unique-identifier"/> 
 	
     <rule context="//pkg:package/pkg:metadata/pkg:dc-metadata">
-        <assert test="dc:Identifier[@id=$uniqueid]">Value of unique-identifier attribute on package element does not match id value of any dc:Identifier.</assert>   					
+        <assert test="dc:Identifier[@id=$uniqueid]">Value of unique-identifier attribute on package element does not match id value of any dc:Identifier.</assert>
+    	
+    	<!-- NIMAS requirements -->
+    	<assert test="count(dc:Format) >= 1">dc:Format metadata is required by NIMAS.</assert>
+    	<assert test="count(dc:Rights) >= 1">dc:Rights metadata is required by NIMAS.</assert>
+    	<assert test="count(dc:Source) >= 1">dc:Source metadata is required by NIMAS.</assert>
+    	<assert test="count(dc:Creator) >=1">dc:Creator metadata is required by NIMAS.</assert>
+    	<assert test="dc:Format[text() = 'NIMAS 1.1']">dc:Format metadata must equal NIMAS 1.1</assert>
+    	<assert test="count(dc:Subject) >=1">dc:Subject is required by NIMAS.</assert>	
     </rule>
     
     <rule context="//pkg:package/pkg:metadata/pkg:x-metadata">
@@ -28,6 +36,31 @@
         <!--<assert test="count(pkg:meta[@name='dtb:totalTime'])=1">dtb:totalTime is missing or duplicated in x-metadata.</assert>-->
 
 
+		<!-- NIMAS requirements -->
+    	<assert test="count(pkg:meta[@name = 'nimas-SourceEdition']) >= 1">nimas-SourceEdition metadata is required by NIMAS.</assert>
+    	<assert test="count(pkg:meta[@name = 'nimas-SourceDate']) >= 1">nimas-SourceDate metadata is required by NIMAS.</assert>
+    	
+    	<!-- these NIMAS metadata requirements came from a NIMAC PDF sent by APH -->
+    	<assert test="count(pkg:meta[@name='DCTERMS.description.note']) >= 1">DCTERMS.description.note metadata is required by NIMAS.</assert>
+    	<assert test="count(pkg:meta[@name='DCTERMS.date.dateCopyrighted']) >= 1">DCTERMS.date.dateCopyrighted metadata is required by NIMAS.</assert>
+    	<assert test="count(pkg:meta[@name='DCTERMS.description.version']) >= 1">DCTERMS.description.version metadata is required by NIMAS.</assert>
+    	<assert test="count(pkg:meta[@name='DCTERMS.audience.educationLevel']) >= 1">DCTERMS.audience.educationLevel metadata is required by NIMAS.</assert>
+    	<assert test="count(pkg:meta[@name='DCTERMS.created']) >= 1">DCTERMS.created metadata is required by NIMAS.</assert>
+    	<assert test="count(pkg:meta[@name='DCTERMS.publisher.place']) >= 1">DCTERMS.publisher.place metadata is required by NIMAS.</assert>
+    	<assert test="count(pkg:meta[@name='DCTERMS.date.issued']) >= 1">DCTERMS.date.issued metadata is required by NIMAS.</assert>
+    	<!--
+    		
+    FUTURE ENHANCEMENTS (NIMAS; from aforementioned PDF):
+    
+        DCTERMS.date.dateCopyrighted // restrict @content to 4 digit year
+        DCTERMS.audience.educationLevel // see controlled vocabulary
+        DCTERMS.created // YYYY-MM-DD
+        DCTERMS.date.issued  // 4 digit year
+        dc:Subject // see controlled vocabulary
+        
+        
+-->
+    	
     </rule>
     
     <rule context="//pkg:package/pkg:manifest">
@@ -58,6 +91,9 @@
     	<assert test="count(pkg:item[@media-type='application/x-dtbresource+xml'])&lt;2"> 
     		Several resource files are listed in manifest.
     	</assert>  
+    	<report test="count(pkg:item[@media-type = 'application/pdf']) = 0"> 
+    		NIMAS requires at least one document with media-type equal to 'application/pdf' in the manifest.
+    	</report>
     </rule>
     
 	<rule context="//pkg:package/pkg:manifest/pkg:item[@media-type='application/x-dtbresource+xml']">
@@ -97,48 +133,7 @@
 		</assert>   					
 	</rule>
 	
-	<!-- NIMAS additions -->
-	<rule context="//pkg:package/pkg:metadata/pkg:dc-metadata">
-		<assert test="count(dc:Format) >= 1">dc:Format metadata is required by NIMAS.</assert>
-		<assert test="count(dc:Rights) >= 1">dc:Rights metadata is required by NIMAS.</assert>
-		<assert test="count(dc:Source) >= 1">dc:Source metadata is required by NIMAS.</assert>
-		<assert test="count(dc:Creator) >=1">dc:Creator metadata is required by NIMAS.</assert>
-		<assert test="dc:Format[text() = 'NIMAS 1.1']">dc:Format must be NIMAS 1.1</assert>
-		<assert test="count(dc:Subject) >=1">dc:Subject is required by NIMAS.</assert>		
-	</rule>
 	
-	<rule context="//pkg:package/pkg:metadata/pkg:x-metadata">
-		<assert test="count(pkg:meta[@name = 'nimas-SourceEdition']) >= 1">nimas-SourceEdition metadata is required by NIMAS.</assert>
-		<assert test="count(pkg:meta[@name = 'nimas-SourceDate']) >= 1">nimas-SourceDate metadata is required by NIMAS.</assert>
-
-        <!-- these NIMAS metadata requirements came from a NIMAC PDF sent by APH -->
-        <assert test="count(pkg:meta[@name='DCTERMS.description.note'])&gt;0">DCTERMS.description.note is required by NIMAS.</assert>
-		<assert test="count(pkg:meta[@name='DCTERMS.date.dateCopyrighted'])&gt;0">DCTERMS.date.dateCopyrighted is required by NIMAS.</assert>
-		<assert test="count(pkg:meta[@name='DCTERMS.description.version'])&gt;0">DCTERMS.description.version is required by NIMAS.</assert>
-		<assert test="count(pkg:meta[@name='DCTERMS.audience.educationLevel'])&gt;0">DCTERMS.audience.educationLevel is required by NIMAS.</assert>
-		<assert test="count(pkg:meta[@name='DCTERMS.created'])&gt;0">DCTERMS.created is required by NIMAS.</assert>
-		<assert test="count(pkg:meta[@name='DCTERMS.publisher.place'])&gt;0">DCTERMS.publisher.place is required by NIMAS.</assert>
-		<assert test="count(pkg:meta[@name='DCTERMS.date.issued'])&gt;0">DCTERMS.date.issued is required by NIMAS.</assert>
-<!--
-
-    FUTURE ENHANCEMENTS (NIMAS; from aforementioned PDF):
-
-        DCTERMS.date.dateCopyrighted // restrict @content to 4 digit year
-        DCTERMS.audience.educationLevel // see controlled vocabulary
-        DCTERMS.created // YYYY-MM-DD
-        DCTERMS.date.issued  // 4 digit year
-        dc:Subject // see controlled vocabulary
-
-
--->
-
-	</rule>
-	
-	<rule context="//pkg:package/pkg:manifest">
-		<report test="count(pkg:item[@media-type = 'application/pdf']) = 0"> 
-			NIMAS requires at least one document with media-type equal to 'application/pdf' in the manifest.
-		</report>
-	</rule>
 	
 	<rule context="//pkg:package/pkg:spine/pkg:itemref">
 		<assert test="//pkg:item[@id=current()/@idref and @media-type='application/x-dtbook+xml']"> 

--- a/nimas-fileset-validator/src/main/resources/xml/schema/sch/mod/package-doc-common.sch
+++ b/nimas-fileset-validator/src/main/resources/xml/schema/sch/mod/package-doc-common.sch
@@ -8,7 +8,8 @@
     	<assert test="count(dc:Format) >= 1">dc:Format metadata is required by NIMAS.</assert>
     	<assert test="count(dc:Rights) >= 1">dc:Rights metadata is required by NIMAS.</assert>
     	<assert test="count(dc:Source) >= 1">dc:Source metadata is required by NIMAS.</assert>
-    	<assert test="count(dc:Creator) >=1">dc:Creator metadata is required by NIMAS.</assert>
+    	<!-- not actually required -->
+    	<!--<assert test="count(dc:Creator) >=1">dc:Creator metadata is required by NIMAS.</assert>-->
     	<assert test="dc:Format[text() = 'NIMAS 1.1']">dc:Format metadata must equal NIMAS 1.1</assert>
     	<assert test="count(dc:Subject) >=1">dc:Subject is required by NIMAS.</assert>	
     </rule>
@@ -37,7 +38,8 @@
 
 
 		<!-- NIMAS requirements -->
-    	<assert test="count(pkg:meta[@name = 'nimas-SourceEdition']) >= 1">nimas-SourceEdition metadata is required by NIMAS.</assert>
+    	<!-- not actually required -->
+    	<!--<assert test="count(pkg:meta[@name = 'nimas-SourceEdition']) >= 1">nimas-SourceEdition metadata is required by NIMAS.</assert>-->
     	<assert test="count(pkg:meta[@name = 'nimas-SourceDate']) >= 1">nimas-SourceDate metadata is required by NIMAS.</assert>
     	
     	<!-- these NIMAS metadata requirements came from a NIMAC PDF sent by APH -->

--- a/nimas-fileset-validator/src/main/resources/xml/schema/sch/mod/package-doc-common.sch
+++ b/nimas-fileset-validator/src/main/resources/xml/schema/sch/mod/package-doc-common.sch
@@ -26,6 +26,8 @@
         <assert test="count(pkg:meta[@name='dtb:revisionDescription'])&lt;2">x-metadata element dtb:revisionDescription occured more than one time.</assert>
     	<!-- DAISY requires this, not NIMAS. We follow NIMAS here. -->
         <!--<assert test="count(pkg:meta[@name='dtb:totalTime'])=1">dtb:totalTime is missing or duplicated in x-metadata.</assert>-->
+
+
     </rule>
     
     <rule context="//pkg:package/pkg:manifest">
@@ -100,11 +102,36 @@
 		<assert test="count(dc:Format) >= 1">dc:Format metadata is required by NIMAS.</assert>
 		<assert test="count(dc:Rights) >= 1">dc:Rights metadata is required by NIMAS.</assert>
 		<assert test="count(dc:Source) >= 1">dc:Source metadata is required by NIMAS.</assert>
+		<assert test="count(dc:Creator) >=1">dc:Creator metadata is required by NIMAS.</assert>
+		<assert test="dc:Format[text() = 'NIMAS 1.1']">dc:Format must be NIMAS 1.1</assert>
+		<assert test="count(dc:Subject) >=1">dc:Subject is required by NIMAS.</assert>		
 	</rule>
 	
 	<rule context="//pkg:package/pkg:metadata/pkg:x-metadata">
 		<assert test="count(pkg:meta[@name = 'nimas-SourceEdition']) >= 1">nimas-SourceEdition metadata is required by NIMAS.</assert>
 		<assert test="count(pkg:meta[@name = 'nimas-SourceDate']) >= 1">nimas-SourceDate metadata is required by NIMAS.</assert>
+
+        <!-- these NIMAS metadata requirements came from a NIMAC PDF sent by APH -->
+        <assert test="count(pkg:meta[@name='DCTERMS.description.note'])&gt;0">DCTERMS.description.note is required by NIMAS.</assert>
+		<assert test="count(pkg:meta[@name='DCTERMS.date.dateCopyrighted'])&gt;0">DCTERMS.date.dateCopyrighted is required by NIMAS.</assert>
+		<assert test="count(pkg:meta[@name='DCTERMS.description.version'])&gt;0">DCTERMS.description.version is required by NIMAS.</assert>
+		<assert test="count(pkg:meta[@name='DCTERMS.audience.educationLevel'])&gt;0">DCTERMS.audience.educationLevel is required by NIMAS.</assert>
+		<assert test="count(pkg:meta[@name='DCTERMS.created'])&gt;0">DCTERMS.created is required by NIMAS.</assert>
+		<assert test="count(pkg:meta[@name='DCTERMS.publisher.place'])&gt;0">DCTERMS.publisher.place is required by NIMAS.</assert>
+		<assert test="count(pkg:meta[@name='DCTERMS.date.issued'])&gt;0">DCTERMS.date.issued is required by NIMAS.</assert>
+<!--
+
+    FUTURE ENHANCEMENTS (NIMAS; from aforementioned PDF):
+
+        DCTERMS.date.dateCopyrighted // restrict @content to 4 digit year
+        DCTERMS.audience.educationLevel // see controlled vocabulary
+        DCTERMS.created // YYYY-MM-DD
+        DCTERMS.date.issued  // 4 digit year
+        dc:Subject // see controlled vocabulary
+
+
+-->
+
 	</rule>
 	
 	<rule context="//pkg:package/pkg:manifest">

--- a/nimas-fileset-validator/src/main/resources/xml/schema/sch/mod/package-doc-with-mathml-mod.sch
+++ b/nimas-fileset-validator/src/main/resources/xml/schema/sch/mod/package-doc-with-mathml-mod.sch
@@ -10,9 +10,9 @@
     -->
 <pattern id="mathml-tests" xmlns="http://purl.oclc.org/dsdl/schematron">
     <!-- these rules don't apply to NIMAS -->
-    <!--
+    
     <rule context="//pkg:package/pkg:metadata/pkg:x-metadata">
-        <report test="count(pkg:meta[@name='z39-86-extension-version']) = 0"> 
+    <!--    <report test="count(pkg:meta[@name='z39-86-extension-version']) = 0"> 
             x-metadata element with name 'z39-86-extension-version' must be present.
         </report>
         <report test="count(pkg:meta[@name='z39-86-extension-version']) > 1"> 
@@ -24,47 +24,56 @@
         <report test="count(pkg:meta[@name='DTBook-XSLTFallback']) > 1"> 
             x-metadata element with name 'DTBook-XSLTFallback' must occur only once.
         </report>
+        -->
     </rule>
-    -->
+    
     <!-- these rules don't apply to NIMAS -->
-    <!--
-        <rule context="//pkg:package/pkg:metadata/pkg:x-metadata/pkg:meta[@name='z39-86-extension-version']">
+   
+    <rule context="//pkg:package/pkg:metadata/pkg:x-metadata/pkg:meta[@name='z39-86-extension-version']">
+        <!--
         <assert test="@content = '1.0'">
             x-metadata element with name 'z39-86-extension-version' must have content attribute value equal to '1.0'.
         </assert>
         <assert test="@scheme = 'http://www.w3.org/1998/Math/MathML'">
             x-metadata element with name 'z39-86-extension-version' must have scheme attribute value equal to 'http://www.w3.org/1998/Math/MathML'.
         </assert>
+        -->
     </rule>
-    -->
+    
     <!-- these rules don't apply to NIMAS -->
-    <!--
+    
     <rule context="//pkg:package/pkg:metadata/pkg:x-metadata/pkg:meta[@name='DTBook-XSLTFallback']">
+        <!--
         <assert test="@scheme = 'http://www.w3.org/1998/Math/MathML'">
             x-metadata element with name 'DTBook-XSLTFallback' must have scheme attribute value equal to 'http://www.w3.org/1998/Math/MathML'.
         </assert>
         <assert test="string-length(@content) > 0">
             x-metadata element with name 'DTBook-XSLTFallback' must have non-empty content attribute value.
         </assert>
+        -->
     </rule>
-    -->
+    
     <!--
             <item href="mathml-fallback-transform.xslt"
               id="XSLT_0"
               media-type="application/xslt+xml" />
       -->
     <!-- these rules don't apply to NIMAS -->
-    <!--
+    
     <let name="xslt-fallback" value="//pkg:package/pkg:metadata/pkg:x-metadata/pkg:meta[@name='DTBook-XSLTFallback']/@content"/> 
     <rule context="//pkg:package/pkg:manifest">
+    <!--
         <assert test="pkg:item[@href = $xslt-fallback]">
             Manifest must contain an item element where the href attribute is equal to the DTBook-XSLTFallback metadata content attribute.
         </assert>
+        -->
     </rule>
     <rule context="//pkg:package/pkg:manifest/pkg:item[@href = $xslt-fallback]">
+        <!--
         <assert test="@media-type = 'application/xslt+xml'">
             XSLT fallback manifest item must have media-type equal to 'application/xslt+xml'.
         </assert>
+        -->
     </rule>
-    -->
+    
 </pattern>

--- a/nimas-fileset-validator/src/main/resources/xml/schema/sch/mod/package-doc-with-mathml-mod.sch
+++ b/nimas-fileset-validator/src/main/resources/xml/schema/sch/mod/package-doc-with-mathml-mod.sch
@@ -9,6 +9,8 @@
           content="xslt-file-name" />
     -->
 <pattern id="mathml-tests" xmlns="http://purl.oclc.org/dsdl/schematron">
+    <!-- these rules don't apply to NIMAS -->
+    <!--
     <rule context="//pkg:package/pkg:metadata/pkg:x-metadata">
         <report test="count(pkg:meta[@name='z39-86-extension-version']) = 0"> 
             x-metadata element with name 'z39-86-extension-version' must be present.
@@ -23,7 +25,10 @@
             x-metadata element with name 'DTBook-XSLTFallback' must occur only once.
         </report>
     </rule>
-    <rule context="//pkg:package/pkg:metadata/pkg:x-metadata/pkg:meta[@name='z39-86-extension-version']">
+    -->
+    <!-- these rules don't apply to NIMAS -->
+    <!--
+        <rule context="//pkg:package/pkg:metadata/pkg:x-metadata/pkg:meta[@name='z39-86-extension-version']">
         <assert test="@content = '1.0'">
             x-metadata element with name 'z39-86-extension-version' must have content attribute value equal to '1.0'.
         </assert>
@@ -31,6 +36,9 @@
             x-metadata element with name 'z39-86-extension-version' must have scheme attribute value equal to 'http://www.w3.org/1998/Math/MathML'.
         </assert>
     </rule>
+    -->
+    <!-- these rules don't apply to NIMAS -->
+    <!--
     <rule context="//pkg:package/pkg:metadata/pkg:x-metadata/pkg:meta[@name='DTBook-XSLTFallback']">
         <assert test="@scheme = 'http://www.w3.org/1998/Math/MathML'">
             x-metadata element with name 'DTBook-XSLTFallback' must have scheme attribute value equal to 'http://www.w3.org/1998/Math/MathML'.
@@ -39,11 +47,14 @@
             x-metadata element with name 'DTBook-XSLTFallback' must have non-empty content attribute value.
         </assert>
     </rule>
+    -->
     <!--
             <item href="mathml-fallback-transform.xslt"
               id="XSLT_0"
               media-type="application/xslt+xml" />
       -->
+    <!-- these rules don't apply to NIMAS -->
+    <!--
     <let name="xslt-fallback" value="//pkg:package/pkg:metadata/pkg:x-metadata/pkg:meta[@name='DTBook-XSLTFallback']/@content"/> 
     <rule context="//pkg:package/pkg:manifest">
         <assert test="pkg:item[@href = $xslt-fallback]">
@@ -55,4 +66,5 @@
             XSLT fallback manifest item must have media-type equal to 'application/xslt+xml'.
         </assert>
     </rule>
+    -->
 </pattern>


### PR DESCRIPTION
Nimas validator revisions:

1. dtbook documents allow empty meta element in head
2. checks for additional nimas metadata
3. bugs fixed in package file schematron

<!---
@huboard:{"order":99.0,"milestone_order":88,"custom_state":""}
-->
